### PR TITLE
feat(git): sync sidebar git status on branch changes from GitHub panel

### DIFF
--- a/src/renderer/components/sidebar/user-account-card.tsx
+++ b/src/renderer/components/sidebar/user-account-card.tsx
@@ -146,6 +146,17 @@ export function UserAccountCard({ collapsed, projectPath }: UserAccountCardProps
     loadGitStatus()
   }, [loadGitStatus])
 
+  // Listen for git status changes (e.g., branch checkout from GitHub tab)
+  useEffect(() => {
+    const handleGitStatusChanged = (e: CustomEvent<{ projectPath: string }>) => {
+      if (e.detail.projectPath === projectPath) {
+        loadGitStatus()
+      }
+    }
+    window.addEventListener('git-status-changed', handleGitStatusChanged as EventListener)
+    return () => window.removeEventListener('git-status-changed', handleGitStatusChanged as EventListener)
+  }, [projectPath, loadGitStatus])
+
   const status = STATUS_STYLES[connectionState]
   const gitRemoteStatus = gitStatus?.hasRemote ? GIT_STATUS_STYLES.connected : GIT_STATUS_STYLES.disconnected
   const username = githubAuth?.username || 'GitHub CLI'

--- a/src/renderer/hooks/use-git-panel.ts
+++ b/src/renderer/hooks/use-git-panel.ts
@@ -173,12 +173,16 @@ export function useGitPanel({ projectPath, enabled = true }: UseGitPanelOptions)
     if (!projectPath) return
     await window.electron.git.checkoutBranch(projectPath, name)
     await refreshAll()
+    // Dispatch event for other components to react to branch change
+    window.dispatchEvent(new CustomEvent('git-status-changed', { detail: { projectPath } }))
   }, [projectPath, refreshAll])
 
   const createBranch = useCallback(async (name: string) => {
     if (!projectPath) return
     await window.electron.git.createBranch(projectPath, name, true)
     await refreshAll()
+    // Dispatch event for other components to react to branch change
+    window.dispatchEvent(new CustomEvent('git-status-changed', { detail: { projectPath } }))
   }, [projectPath, refreshAll])
 
   const deleteBranch = useCallback(async (name: string, force = false) => {


### PR DESCRIPTION
## Summary
- Add custom event dispatch when branches are checked out or created via GitHub tab
- Add event listener in sidebar to refresh git status on branch changes
- Ensures sidebar git status stays in sync with GitHub panel operations

## Test plan
- [x] Checkout a branch from GitHub tab, verify sidebar updates
- [x] Create a new branch from GitHub tab, verify sidebar updates