### PR TITLE
fix(terminal): stabilize resize replay

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -230,6 +230,10 @@ export function registerIpcHandlers(window: BrowserWindow, managers: Managers) {
     terminalManager.resize(terminalId, cols, rows)
   })
 
+  safeOn(IPC_CHANNELS.TERMINAL_RESIZE_HEADLESS, (_, { terminalId, cols, rows }) => {
+    terminalManager.resizeHeadless(terminalId, cols, rows)
+  })
+
   safeHandle(IPC_CHANNELS.TERMINAL_LIST, async () => {
     return terminalManager.list()
   })

--- a/src/main/terminal/__tests__/terminal-manager.spec.ts
+++ b/src/main/terminal/__tests__/terminal-manager.spec.ts
@@ -102,6 +102,28 @@ describe('TerminalManager', () => {
       const term = manager.create()
       expect(term.allowTitleUpdate).toBe(false)
     })
+
+    it('emits output stream offsets for snapshot/live dedupe', () => {
+      const term = manager.create()
+      const outputListener = vi.fn()
+      manager.on('output', outputListener)
+
+      mockPty._dataCallback?.('hello')
+      mockPty._dataCallback?.(' world')
+
+      expect(outputListener).toHaveBeenNthCalledWith(1, {
+        terminalId: term.id,
+        data: 'hello',
+        startOffset: 0,
+        endOffset: 5,
+      })
+      expect(outputListener).toHaveBeenNthCalledWith(2, {
+        terminalId: term.id,
+        data: ' world',
+        startOffset: 5,
+        endOffset: 11,
+      })
+    })
   })
 
   describe('write', () => {
@@ -157,6 +179,20 @@ describe('TerminalManager', () => {
 
     it('returns false for non-existent terminal', () => {
       expect(manager.resize('invalid', 80, 24)).toBe(false)
+    })
+  })
+
+  describe('resizeHeadless', () => {
+    it('resizes the headless mirror without sending SIGWINCH to the PTY', () => {
+      const term = manager.create()
+      const result = manager.resizeHeadless(term.id, 92, 28)
+
+      expect(result).toBe(true)
+      expect(mockPty.resize).not.toHaveBeenCalledWith(92, 28)
+    })
+
+    it('returns false for non-existent terminal', () => {
+      expect(manager.resizeHeadless('invalid', 80, 24)).toBe(false)
     })
   })
 
@@ -606,6 +642,21 @@ describe('TerminalManager', () => {
       expect(count3).toBe(1)
     })
 
+    it('replays raw transcript with resize history so old redraw lines are not baked in', async () => {
+      const term = manager.create()
+
+      manager.resize(term.id, 20, 8)
+      mockPty._dataCallback?.('12345678901234567890')
+      mockPty._dataCallback?.('\r\x1b[Kshort\r\n')
+      manager.resize(term.id, 8, 8)
+
+      await manager.rebuildHeadless(term.id)
+      const snap = await manager.getSnapshot(term.id)
+
+      expect(snap.data).toContain('short')
+      expect(snap.data).not.toContain('1234567890123456')
+    })
+
     it('does not duplicate live PTY data that arrives during rebuild', async () => {
       const term = manager.create()
 
@@ -628,6 +679,44 @@ describe('TerminalManager', () => {
 
       expect(initialCount).toBe(1)
       expect(concurrentCount).toBe(1)
+    })
+
+    it('preserves a resize that arrives while headless is rebuilding', async () => {
+      const term = manager.create()
+      mockPty._dataCallback?.('before-resize\r\n')
+
+      const rebuildPromise = manager.rebuildHeadless(term.id)
+      manager.resize(term.id, 40, 12)
+      await rebuildPromise
+
+      const snap = await manager.getSnapshot(term.id)
+      expect(snap.cols).toBe(40)
+      expect(snap.rows).toBe(12)
+    })
+
+    it('applies a resize that arrives while replaying rebuild tail bytes', async () => {
+      const term = manager.create()
+      mockPty._dataCallback?.('before-tail\r\n')
+
+      const replayTarget = manager as unknown as {
+        replayPayloadWithResizeHistory: (...args: unknown[]) => Promise<boolean>
+      }
+      const originalReplay = replayTarget.replayPayloadWithResizeHistory.bind(replayTarget)
+      const replaySpy = vi.spyOn(replayTarget, 'replayPayloadWithResizeHistory')
+      replaySpy.mockImplementation(async (...args: unknown[]) => {
+        if (replaySpy.mock.calls.length === 2) {
+          manager.resize(term.id, 52, 13)
+        }
+        return originalReplay(...args)
+      })
+
+      const rebuildPromise = manager.rebuildHeadless(term.id)
+      mockPty._dataCallback?.('tail-bytes\r\n')
+      await rebuildPromise
+
+      const snap = await manager.getSnapshot(term.id)
+      expect(snap.cols).toBe(52)
+      expect(snap.rows).toBe(13)
     })
 
     it('is a no-op and does not throw when terminal is destroying', async () => {

--- a/src/main/terminal/__tests__/terminal-snapshot.spec.ts
+++ b/src/main/terminal/__tests__/terminal-snapshot.spec.ts
@@ -88,6 +88,7 @@ describe('TerminalManager.getSnapshot', () => {
     // dims must reflect actual terminal size (default 80x24)
     expect(snap.cols).toBeGreaterThan(0)
     expect(snap.rows).toBeGreaterThan(0)
+    expect(snap.byteOffset).toBe('line1\r\nline2\r\n'.length)
   })
 
   it('(a) includes timing: snapshot serialize latency <60ms for typical scrollback', async () => {

--- a/src/main/terminal/terminal-manager.ts
+++ b/src/main/terminal/terminal-manager.ts
@@ -35,6 +35,10 @@ interface PTYProcess {
   // Absolute byte position of outputBuffer[0] in the monotonic stream.
   // Invariant: bufferStartOffset + outputBuffer.length === bytesWritten
   bufferStartOffset: number
+  // Resize history keyed by output byte offset. Raw transcript replay must
+  // preserve historical widths because inline redraw sequences depend on the
+  // width at the time they were emitted.
+  resizeMarkers: ResizeMarker[]
   inputBuffer: string
   lastOutputAt: number // Timestamp of last output for busy detection
   oscBuffer: string // Buffer for incomplete OSC sequences
@@ -44,6 +48,12 @@ interface PTYProcess {
   // Phase 1: headless terminal mirror for snapshot/restore
   headlessTerm?: HeadlessTerminal
   serializeAddon?: SerializeAddon
+}
+
+interface ResizeMarker {
+  offset: number
+  cols: number
+  rows: number
 }
 
 export class TerminalManager extends EventEmitter {
@@ -461,6 +471,7 @@ export class TerminalManager extends EventEmitter {
       outputBuffer: '',
       bytesWritten: 0,
       bufferStartOffset: 0,
+      resizeMarkers: [{ offset: 0, cols: 80, rows: 24 }],
       inputBuffer: '',
       lastOutputAt: 0,
       oscBuffer: ''
@@ -499,6 +510,7 @@ export class TerminalManager extends EventEmitter {
       // Skip headless write during rebuild — outputBuffer accumulates the data,
       // and the replay in rebuildHeadless() covers it. Writing here AND replaying
       // would duplicate content (C1 concurrent-write race fix).
+      const outputStartOffset = termProcess.bytesWritten
       if (!termProcess.rebuildingHeadless) {
         termProcess.headlessTerm?.write(data)
       }
@@ -506,6 +518,7 @@ export class TerminalManager extends EventEmitter {
       // Raw-ANSI buffer — Telegram text-only path only. Visual source of truth = headless snapshot (getSnapshot).
       termProcess.outputBuffer += data
       termProcess.bytesWritten += data.length
+      const outputEndOffset = termProcess.bytesWritten
       termProcess.lastOutputAt = Date.now()
       if (termProcess.outputBuffer.length > TERMINAL_OUTPUT_BUFFER_MAX) {
         const beforeLen = termProcess.outputBuffer.length
@@ -517,8 +530,14 @@ export class TerminalManager extends EventEmitter {
         // map captured offsets through trims that happen during replay.
         termProcess.bufferStartOffset += beforeLen - trimmed.length
         termProcess.outputBuffer = trimmed
+        this.trimResizeMarkers(termProcess)
       }
-      this.emit('output', { terminalId: id, data })
+      this.emit('output', {
+        terminalId: id,
+        data,
+        startOffset: outputStartOffset,
+        endOffset: outputEndOffset
+      })
 
       // Parse OSC sequences for title changes
       this.parseOscTitle(termProcess, data)
@@ -599,6 +618,7 @@ export class TerminalManager extends EventEmitter {
     }
     try {
       term.pty.resize(cols, rows)
+      this.recordResizeMarker(term, cols, rows)
       // Phase 1: resize headless mirror inside same try block (validation V1).
       // Skip resize during rebuild — freshTerm is created at the current cols, a
       // concurrent resize here would re-introduce the wrong-width artifact (C1).
@@ -611,6 +631,95 @@ export class TerminalManager extends EventEmitter {
       console.error(`[terminal-manager] Resize failed for ${id}:`, (error as Error).message)
       return false
     }
+  }
+
+  resizeHeadless(id: string, cols: number, rows: number): boolean {
+    const term = this.terminals.get(id)
+    if (!term || term.destroying) return false
+    try {
+      this.recordResizeMarker(term, cols, rows)
+      if (!term.rebuildingHeadless) {
+        term.headlessTerm?.resize(cols, rows)
+      }
+      return true
+    } catch (error) {
+      console.error(`[terminal-manager] Headless resize failed for ${id}:`, (error as Error).message)
+      return false
+    }
+  }
+
+  private recordResizeMarker(term: PTYProcess, cols: number, rows: number): void {
+    const offset = term.bytesWritten
+    const last = term.resizeMarkers[term.resizeMarkers.length - 1]
+    if (last?.cols === cols && last.rows === rows) return
+    if (last?.offset === offset) {
+      last.cols = cols
+      last.rows = rows
+    } else {
+      term.resizeMarkers.push({ offset, cols, rows })
+    }
+    this.trimResizeMarkers(term)
+  }
+
+  private trimResizeMarkers(term: PTYProcess): void {
+    const start = term.bufferStartOffset
+    const markers = term.resizeMarkers
+    if (markers.length <= 1) return
+
+    let keepFrom = 0
+    for (let i = 0; i < markers.length; i++) {
+      if (markers[i].offset <= start) keepFrom = i
+      else break
+    }
+
+    if (keepFrom > 0) {
+      term.resizeMarkers = markers.slice(keepFrom)
+    }
+  }
+
+  private getReplayResizeMarkers(term: PTYProcess, startByte: number, endByte: number): ResizeMarker[] {
+    const markers = term.resizeMarkers
+    let initial = markers[0] ?? { offset: startByte, cols: 80, rows: 24 }
+
+    for (const marker of markers) {
+      if (marker.offset <= startByte) initial = marker
+      else break
+    }
+
+    return [
+      { ...initial, offset: startByte },
+      ...markers
+        .filter(marker => marker.offset > startByte && marker.offset <= endByte)
+        .map(marker => ({ ...marker })),
+    ]
+  }
+
+  private async replayPayloadWithResizeHistory(
+    terminal: HeadlessTerminal,
+    payload: string,
+    startByte: number,
+    markers: ResizeMarker[]
+  ): Promise<boolean> {
+    let timedOut = false
+    let cursor = 0
+
+    const writeSegment = async (segment: string): Promise<void> => {
+      if (!segment) return
+      await Promise.race([
+        new Promise<void>(resolve => terminal.write(segment, resolve)),
+        new Promise<void>(resolve => setTimeout(() => { timedOut = true; resolve() }, 5000)),
+      ])
+    }
+
+    for (const marker of markers.slice(1)) {
+      const nextCursor = Math.max(0, Math.min(payload.length, marker.offset - startByte))
+      await writeSegment(payload.slice(cursor, nextCursor))
+      terminal.resize(marker.cols, marker.rows)
+      cursor = nextCursor
+    }
+
+    await writeSegment(payload.slice(cursor))
+    return timedOut
   }
 
   /**
@@ -633,7 +742,7 @@ export class TerminalManager extends EventEmitter {
    *
    * Re-checks process existence after await to guard against PTY exit during serialize.
    */
-  async getSnapshot(id: string): Promise<{ data: string; cols: number; rows: number }> {
+  async getSnapshot(id: string): Promise<{ data: string; cols: number; rows: number; byteOffset?: number }> {
     const empty = { data: '', cols: 0, rows: 0 }
     const proc = this.terminals.get(id)
     if (!proc?.headlessTerm || !proc.serializeAddon) return empty
@@ -647,6 +756,7 @@ export class TerminalManager extends EventEmitter {
         data: current.serializeAddon.serialize({ scrollback: HEADLESS_SCROLLBACK_LINES }),
         cols: current.headlessTerm.cols,
         rows: current.headlessTerm.rows,
+        byteOffset: current.bytesWritten,
       }
     } catch (err) {
       console.warn('[terminal-manager] getSnapshot failed', { id, err: (err as Error).message })
@@ -683,10 +793,6 @@ export class TerminalManager extends EventEmitter {
     // outputBuffer keeps accumulating; replay+tail-flush below cover all bytes.
     proc.rebuildingHeadless = true
 
-    // Capture current dimensions before disposing
-    const cols = proc.headlessTerm.cols || 80
-    const rows = proc.headlessTerm.rows || 24
-
     // Dispose existing headless + addon to free memory before allocating new ones
     try { proc.serializeAddon?.dispose() } catch { /* ignore */ }
     try { proc.headlessTerm.dispose() } catch { /* ignore */ }
@@ -697,29 +803,34 @@ export class TerminalManager extends EventEmitter {
       // Guard: PTY may have exited during the dispose calls above
       if (proc.destroying || !this.terminals.has(id)) return
 
+      // C2: snapshot the replay payload + absolute end-byte synchronously, so the
+      // tail-flush window survives any trim that runs during the await below.
+      const replayStartByte = proc.bufferStartOffset
+      const replayPayload = proc.outputBuffer
+      const replayEndByte = proc.bytesWritten
+      const replayMarkers = this.getReplayResizeMarkers(proc, replayStartByte, replayEndByte)
+      const initialSize = replayMarkers[0] ?? { cols: 80, rows: 24 }
+
       const freshTerm = new HeadlessTerminalCtor({
-        cols,
-        rows,
+        cols: initialSize.cols,
+        rows: initialSize.rows,
         scrollback: HEADLESS_SCROLLBACK_LINES,
         allowProposedApi: true,
       })
       const freshAddon = new SerializeAddon()
       freshTerm.loadAddon(freshAddon as unknown as Parameters<typeof freshTerm.loadAddon>[0])
 
-      // C2: snapshot the replay payload + absolute end-byte synchronously, so the
-      // tail-flush window survives any trim that runs during the await below.
-      const replayPayload = proc.outputBuffer
-      const replayEndByte = proc.bytesWritten
-
       // Replay raw transcript at the current column width BEFORE attaching to proc.
       // Race with a 5 s timeout in case freshTerm is disposed mid-write and the
       // callback never fires; 5 s far exceeds the ~100-300 ms cost of 3 MB replay.
       let replayTimedOut = false
       if (replayPayload) {
-        await Promise.race([
-          new Promise<void>(resolve => freshTerm.write(replayPayload, resolve)),
-          new Promise<void>(resolve => setTimeout(() => { replayTimedOut = true; resolve() }, 5000)),
-        ])
+        replayTimedOut = await this.replayPayloadWithResizeHistory(
+          freshTerm,
+          replayPayload,
+          replayStartByte,
+          replayMarkers
+        )
         if (replayTimedOut) {
           console.warn('[terminal-manager] rebuildHeadless: replay write timed out at 5s', { id, payloadBytes: replayPayload.length })
         }
@@ -745,15 +856,27 @@ export class TerminalManager extends EventEmitter {
       const tail = tailStartIdx < proc.outputBuffer.length
         ? proc.outputBuffer.slice(tailStartIdx)
         : ''
+      const tailEndByte = proc.bytesWritten
+      const tailMarkers = this.getReplayResizeMarkers(proc, tailStartByte, tailEndByte)
+      const tailInitialSize = tailMarkers[0]
+      if (tailInitialSize) {
+        freshTerm.resize(tailInitialSize.cols, tailInitialSize.rows)
+      }
       if (tail) {
-        let tailTimedOut = false
-        await Promise.race([
-          new Promise<void>(resolve => freshTerm.write(tail, resolve)),
-          new Promise<void>(resolve => setTimeout(() => { tailTimedOut = true; resolve() }, 5000)),
-        ])
+        const tailTimedOut = await this.replayPayloadWithResizeHistory(
+          freshTerm,
+          tail,
+          tailStartByte,
+          tailMarkers
+        )
         if (tailTimedOut) {
           console.warn('[terminal-manager] rebuildHeadless: tail write timed out at 5s', { id, tailBytes: tail.length })
         }
+      }
+
+      const latestMarker = proc.resizeMarkers[proc.resizeMarkers.length - 1]
+      if (latestMarker) {
+        freshTerm.resize(latestMarker.cols, latestMarker.rows)
       }
     } catch (err) {
       // Non-fatal: headless rebuild failed — next getSnapshot will return stale/empty data,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,13 +36,14 @@ export interface ElectronAPI {
     destroy: (id: string) => Promise<boolean>
     write: (terminalId: string, data: string) => void
     resize: (terminalId: string, cols: number, rows: number) => void
+    resizeHeadless: (terminalId: string, cols: number, rows: number) => void
     list: () => Promise<Terminal[]>
     invokeClaude: (terminalId: string, sessionId?: string) => Promise<boolean>
     detectWsl: () => Promise<WslInfo>
     getAvailableShells: () => Promise<import('@shared/types').ShellInfo[]>
     loadPaneTree: (projectId: string) => Promise<import('@shared/types').PaneTree | null>
     savePaneTree: (projectId: string, tree: import('@shared/types').PaneTree | null) => Promise<void>
-    getSnapshot: (terminalId: string) => Promise<{ data: string; cols: number; rows: number }>
+    getSnapshot: (terminalId: string) => Promise<{ data: string; cols: number; rows: number; byteOffset?: number }>
     /**
      * Part F: Rebuild the headless mirror from the raw PTY transcript at current dimensions.
      * Call this before getSnapshot to ensure the snapshot is free of xterm reflow artifacts
@@ -50,7 +51,7 @@ export interface ElectronAPI {
      * the one at which output was originally produced).
      */
     rebuildHeadless: (terminalId: string) => Promise<void>
-    onOutput: (callback: (data: { terminalId: string; data: string }) => void) => () => void
+    onOutput: (callback: (data: { terminalId: string; data: string; startOffset?: number; endOffset?: number }) => void) => () => void
     onExit: (callback: (data: { terminalId: string; exitCode: number }) => void) => () => void
     onTitleChange: (callback: (data: { terminalId: string; title: string }) => void) => () => void
     onStateChange: (callback: (data: { terminalId: string; isClaudeMode: boolean }) => void) => () => void
@@ -234,6 +235,8 @@ const api: ElectronAPI = {
     destroy: (id) => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_DESTROY, id),
     write: (terminalId, data) => ipcRenderer.send(IPC_CHANNELS.TERMINAL_INPUT, { terminalId, data }),
     resize: (terminalId, cols, rows) => ipcRenderer.send(IPC_CHANNELS.TERMINAL_RESIZE, { terminalId, cols, rows }),
+    resizeHeadless: (terminalId, cols, rows) =>
+      ipcRenderer.send(IPC_CHANNELS.TERMINAL_RESIZE_HEADLESS, { terminalId, cols, rows }),
     list: () => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_LIST),
     invokeClaude: (terminalId, sessionId) => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_INVOKE_CLAUDE, { terminalId, sessionId }),
     detectWsl: () => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_DETECT_WSL),
@@ -242,7 +245,7 @@ const api: ElectronAPI = {
     savePaneTree: (projectId, tree) => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_SAVE_PANE_TREE, { projectId, tree }),
     getSnapshot: (terminalId) =>
       ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_GET_SNAPSHOT, terminalId) as
-        Promise<{ data: string; cols: number; rows: number }>,
+        Promise<{ data: string; cols: number; rows: number; byteOffset?: number }>,
     rebuildHeadless: (terminalId) =>
       ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_REBUILD_HEADLESS, terminalId) as Promise<void>,
     onOutput: (callback) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,6 +27,7 @@ import { shellInfoToWindowsShell } from './utils'
 import { reconcileSavedDefaultShell } from './utils/default-shell-selection'
 import { attachTerminalOutputDispatcher } from './utils/terminal-output-dispatcher'
 import { attachTerminalLifecycleDispatcher } from './utils/terminal-lifecycle-dispatcher'
+import { suppressAutoResizeRefreshForTerminals } from './utils/terminal-resize-end-dispatcher'
 import { THEMES, APP_FONTS, getTerminalFontFamilyById } from '@shared/constants'
 import type { ShellInfo, Project } from '@shared/types'
 
@@ -229,6 +230,15 @@ function App() {
     const idToClose = terminalId ?? activeTerminalId
     if (!idToClose) return
     await window.electron.terminal.destroy(idToClose)
+    const terminalIdsToSuppress = useAppStore
+      .getState()
+      .terminals
+      .filter((terminal) =>
+        terminal.id !== idToClose &&
+        (!activeProjectId || terminal.projectId === activeProjectId)
+      )
+      .map((terminal) => terminal.id)
+    suppressAutoResizeRefreshForTerminals(terminalIdsToSuppress)
     removeTerminal(idToClose)
     // Collapse the pane tree node for this terminal so parents reflow.
     if (activeProjectId) {

--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -8,6 +8,7 @@ beforeEach(() => {
     terminal: {
       input: vi.fn(),
       resize: vi.fn(),
+      resizeHeadless: vi.fn(),
     },
     clipboard: { writeText: vi.fn() },
     shell: { openPath: vi.fn(), openExternal: vi.fn() },

--- a/src/renderer/components/settings/terminal-settings.tsx
+++ b/src/renderer/components/settings/terminal-settings.tsx
@@ -400,10 +400,10 @@ export function TerminalSettings() {
             Auto-rebuild Scrollback on Resize
           </p>
           <p className="text-xs text-[var(--mc-text-muted)] mt-1">
-            The Refresh button always rebuilds scrollback from the raw PTY transcript
-            to eliminate blank gaps from xterm reflow. Enable this option to also do
-            it automatically every time the terminal width changes (split, resize,
-            project switch). Adds ~100-300ms CPU per resize.
+            The Refresh button rebuilds scrollback from the raw PTY transcript to
+            eliminate xterm reflow artifacts. Enable this option to also do it
+            automatically after non-drag terminal width changes, such as window
+            resize or project switch. Adds ~100-300ms CPU per rebuild.
           </p>
         </div>
         <div className="flex items-start gap-3 pt-1">
@@ -416,8 +416,8 @@ export function TerminalSettings() {
               Enable auto-rebuild on width change
             </p>
             <p className="text-xs text-[var(--mc-text-muted)] mt-0.5">
-              Off by default. Useful for split-heavy workflows; causes a brief CPU
-              spike on each resize.
+              Off by default; pane divider drags resize live without replaying the
+              terminal buffer.
             </p>
           </div>
         </div>

--- a/src/renderer/hooks/__tests__/use-pane-resize.spec.ts
+++ b/src/renderer/hooks/__tests__/use-pane-resize.spec.ts
@@ -186,6 +186,28 @@ describe('usePaneResize', () => {
     expect(setRatio).toHaveBeenLastCalledWith(0.6)
   })
 
+  it('defaults to the ratio clamp when the pixel minimum is looser', () => {
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({ width: 1000, height: 100, top: 0, left: 0, right: 1000, bottom: 100, x: 0, y: 0, toJSON: () => ({}) }),
+      configurable: true,
+      writable: true
+    })
+
+    const { result } = renderHook(() =>
+      usePaneResize({
+        orientation: 'row',
+        startRatio: 0.5,
+        containerRef: { current: container },
+        onRatioChange: setRatio
+      })
+    )
+
+    act(() => result.current.beginDrag(fakePointerDown(handle, 500, 0)))
+    act(() => dispatchMove(handle, 0, 0))
+
+    expect(setRatio).toHaveBeenLastCalledWith(0.1)
+  })
+
   it('unmount mid-drag cleans up listeners (no onRatioChange after unmount)', () => {
     const { result, unmount } = mount('row', 0.5)
     act(() => result.current.beginDrag(fakePointerDown(handle, 100, 0)))

--- a/src/renderer/hooks/__tests__/use-terminal-fit.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-fit.spec.ts
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { MIN_SAFE_COLS, useTerminalFit, type ResizeColsChange } from '../use-terminal-fit'
+import { setPaneDragging } from '../../utils/pane-drag-state'
+import { resetResizeEndDispatcherForTests, suppressAutoResizeRefresh } from '../../utils/terminal-resize-end-dispatcher'
+import { DEFAULT_SETTINGS } from '@shared/constants'
+import { useSettingsStore } from '../../stores'
+
+function makeTerminal(cols = 80, rows = 24, bufferType: 'normal' | 'alternate' = 'normal') {
+  return {
+    cols,
+    rows,
+    buffer: { active: { type: bufferType, viewportY: 0, baseY: 0 } },
+    resize: vi.fn(function (this: { cols: number; rows: number }, nextCols: number, nextRows: number) {
+      this.cols = nextCols
+      this.rows = nextRows
+    }),
+    scrollToBottom: vi.fn(),
+    scrollToLine: vi.fn(),
+  }
+}
+
+function renderUseTerminalFit(
+  proposed: { cols: number; rows: number },
+  onResizeEnd?: (source: 'pane-drag' | 'window', colsChanged: ResizeColsChange) => void,
+  onColsChanged?: () => void,
+  options: { initialCols?: number; initialRows?: number; bufferType?: 'normal' | 'alternate' } = {}
+) {
+  const terminal = makeTerminal(options.initialCols, options.initialRows, options.bufferType)
+  const fitAddon = {
+    fit: vi.fn(() => {
+      terminal.cols = proposed.cols
+      terminal.rows = proposed.rows
+    }),
+    proposeDimensions: vi.fn(() => proposed),
+  }
+  const refreshVisibleRows = vi.fn()
+
+  const hook = renderHook(() =>
+    useTerminalFit({
+      terminalId: 'test-term',
+      terminalRef: { current: terminal } as never,
+      fitAddonRef: { current: fitAddon } as never,
+      containerRef: {
+        current: { clientWidth: 160, clientHeight: 240 },
+      } as never,
+      disposedRef: { current: false },
+      scrollMachineRef: { current: { isAtBottom: true } } as never,
+      refreshVisibleRows,
+      onColsChanged,
+      onResizeEnd,
+    })
+  )
+
+  return { ...hook, terminal, fitAddon, refreshVisibleRows }
+}
+
+describe('useTerminalFit', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(performance.now())
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    resetResizeEndDispatcherForTests()
+    useSettingsStore.setState({
+      savedSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: false },
+      pendingSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: false },
+      settings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: false },
+    })
+  })
+
+  afterEach(() => {
+    setPaneDragging(false)
+    resetResizeEndDispatcherForTests()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('fits normally when proposed cols are safe', () => {
+    const { result, terminal, fitAddon } = renderUseTerminalFit({ cols: 40, rows: 20 })
+
+    expect(result.current.performFit()).toBe(true)
+
+    expect(fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(terminal.resize).not.toHaveBeenCalled()
+    expect(terminal.cols).toBe(40)
+    expect(terminal.rows).toBe(20)
+  })
+
+  it('clamps very narrow panes to the minimum safe cols', () => {
+    const { result, terminal, fitAddon } = renderUseTerminalFit({ cols: 12, rows: 20 })
+
+    expect(result.current.performFit()).toBe(true)
+
+    expect(fitAddon.fit).not.toHaveBeenCalled()
+    expect(terminal.resize).toHaveBeenCalledWith(MIN_SAFE_COLS, 20)
+    expect(terminal.cols).toBe(MIN_SAFE_COLS)
+    expect(terminal.rows).toBe(20)
+  })
+
+  it('clamps very narrow alt-screen panes to the minimum safe cols', () => {
+    const { result, terminal, fitAddon } = renderUseTerminalFit(
+      { cols: 12, rows: 20 },
+      undefined,
+      undefined,
+      { bufferType: 'alternate' }
+    )
+
+    expect(result.current.performFit()).toBe(true)
+
+    expect(fitAddon.fit).not.toHaveBeenCalled()
+    expect(terminal.resize).toHaveBeenCalledWith(MIN_SAFE_COLS, 20)
+    expect(terminal.cols).toBe(MIN_SAFE_COLS)
+    expect(terminal.rows).toBe(20)
+  })
+
+  it('reports pane-drag resize-end after responsive normal-buffer shrink', () => {
+    vi.useFakeTimers()
+    const onResizeEnd = vi.fn()
+    const proposed = { cols: 80, rows: 20 }
+    const { result, terminal } = renderUseTerminalFit(proposed, onResizeEnd)
+
+    expect(result.current.performFit()).toBe(true)
+    proposed.cols = 40
+
+    act(() => setPaneDragging(true))
+    act(() => result.current.fit())
+    act(() => vi.advanceTimersByTime(16))
+    expect(terminal.cols).toBe(40)
+    act(() => setPaneDragging(false))
+    act(() => vi.advanceTimersByTime(350))
+
+    expect(terminal.cols).toBe(40)
+    expect(onResizeEnd).toHaveBeenCalledWith('pane-drag', { changed: true, direction: 'narrower' })
+  })
+
+  it('keeps pane-drag resize-end open for a late post-drag shrink fit', () => {
+    vi.useFakeTimers()
+    const onResizeEnd = vi.fn()
+    const proposed = { cols: 80, rows: 20 }
+    const { result, terminal } = renderUseTerminalFit(proposed, onResizeEnd)
+
+    expect(result.current.performFit()).toBe(true)
+
+    act(() => setPaneDragging(true))
+    act(() => result.current.fit())
+    act(() => setPaneDragging(false))
+    act(() => vi.advanceTimersByTime(100))
+
+    proposed.cols = 44
+    act(() => result.current.fit())
+    act(() => vi.advanceTimersByTime(400))
+    expect(terminal.cols).toBe(44)
+    expect(onResizeEnd).toHaveBeenCalledWith('pane-drag', { changed: true, direction: 'narrower' })
+  })
+
+  it('reports pane-drag resize-end as wider when final cols grow', () => {
+    vi.useFakeTimers()
+    const onResizeEnd = vi.fn()
+    const proposed = { cols: 40, rows: 20 }
+    const { result } = renderUseTerminalFit(
+      proposed,
+      onResizeEnd,
+      undefined,
+      { initialCols: 40 }
+    )
+
+    expect(result.current.performFit()).toBe(true)
+    proposed.cols = 80
+
+    act(() => setPaneDragging(true))
+    act(() => result.current.fit())
+    act(() => setPaneDragging(false))
+    act(() => vi.advanceTimersByTime(350))
+
+    expect(onResizeEnd).toHaveBeenCalledWith('pane-drag', { changed: true, direction: 'wider' })
+  })
+
+  it('does not auto-rebuild scrollback for split-triggered column changes', () => {
+    vi.useFakeTimers()
+    useSettingsStore.setState({
+      savedSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      pendingSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      settings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+    })
+
+    const onColsChanged = vi.fn()
+    const proposed = { cols: 80, rows: 20 }
+    const { result } = renderUseTerminalFit(proposed, undefined, onColsChanged)
+
+    expect(result.current.performFit()).toBe(true)
+
+    suppressAutoResizeRefresh('test-term')
+    proposed.cols = 40
+    expect(result.current.performFit()).toBe(true)
+    act(() => vi.advanceTimersByTime(400))
+
+    expect(onColsChanged).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-rebuild scrollback while a pane-drag shrink settles', () => {
+    vi.useFakeTimers()
+    useSettingsStore.setState({
+      savedSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      pendingSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      settings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+    })
+
+    const onColsChanged = vi.fn()
+    const proposed = { cols: 80, rows: 20 }
+    const { result } = renderUseTerminalFit(proposed, undefined, onColsChanged)
+
+    expect(result.current.performFit()).toBe(true)
+    proposed.cols = 40
+
+    act(() => setPaneDragging(true))
+    act(() => result.current.fit())
+    expect(result.current.performFit()).toBe(true)
+    act(() => setPaneDragging(false))
+    act(() => vi.advanceTimersByTime(400))
+
+    expect(onColsChanged).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-rebuild scrollback while a pane-drag widen settles', () => {
+    vi.useFakeTimers()
+    useSettingsStore.setState({
+      savedSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      pendingSettings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+      settings: { ...DEFAULT_SETTINGS, reflowSafeScrollback: true },
+    })
+
+    const onColsChanged = vi.fn()
+    const onResizeEnd = vi.fn()
+    const proposed = { cols: 40, rows: 20 }
+    const { result } = renderUseTerminalFit(
+      proposed,
+      onResizeEnd,
+      onColsChanged,
+      { initialCols: 40 }
+    )
+
+    expect(result.current.performFit()).toBe(true)
+    proposed.cols = 80
+
+    act(() => setPaneDragging(true))
+    act(() => result.current.fit())
+    act(() => setPaneDragging(false))
+    act(() => vi.advanceTimersByTime(400))
+
+    expect(onResizeEnd).toHaveBeenCalledWith('pane-drag', { changed: true, direction: 'wider' })
+    expect(onColsChanged).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/__tests__/use-terminal-init-resize.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-init-resize.spec.ts
@@ -1,0 +1,319 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalInit } from '../use-terminal-init'
+import { MIN_SAFE_COLS } from '../use-terminal-fit'
+import { _resetForTests as resetPtyResizeCoordinatorForTests } from '../../utils/pty-resize-coordinator'
+import {
+  attachTerminalOutputDispatcher,
+  registerTerminalOutputHandler,
+  resetTerminalOutputDispatcherForTests,
+} from '../../utils/terminal-output-dispatcher'
+import { useAppStore } from '../../stores'
+
+const terminalMocks = vi.hoisted(() => ({
+  latest: null as MockTerminal | null,
+  latestOptions: null as Record<string, unknown> | null,
+  proposed: { cols: 120, rows: 30 },
+  fitThrows: false,
+}))
+
+class MockTerminal {
+  cols = 120
+  rows = 30
+  element: HTMLElement | null = null
+  textarea: HTMLTextAreaElement | null = null
+  buffer = { active: { type: 'normal', viewportY: 0, baseY: 0 } }
+  options = {}
+  open = vi.fn()
+  loadAddon = vi.fn()
+  resize = vi.fn((cols: number, rows: number) => {
+    this.cols = cols
+    this.rows = rows
+  })
+  write = vi.fn((_data: string, cb?: () => void) => cb?.())
+  onScroll = vi.fn(() => ({ dispose: vi.fn() }))
+  onWriteParsed = vi.fn()
+  attachCustomKeyEventHandler = vi.fn()
+  onData = vi.fn()
+  onResize = vi.fn((cb: (size: { cols: number; rows: number }) => void) => {
+    this.resizeListener = cb
+    return { dispose: vi.fn() }
+  })
+  resizeListener?: (size: { cols: number; rows: number }) => void
+  emitResize(cols: number, rows: number) {
+    this.cols = cols
+    this.rows = rows
+    this.resizeListener?.({ cols, rows })
+  }
+}
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function Terminal(options: Record<string, unknown>) {
+    terminalMocks.latestOptions = options
+    terminalMocks.latest = new MockTerminal()
+    return terminalMocks.latest
+  }),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function FitAddon() {
+    return {
+      fit: vi.fn(() => {
+        if (terminalMocks.fitThrows) throw new Error('fit failed')
+        if (!terminalMocks.latest) return
+        terminalMocks.latest.cols = terminalMocks.proposed.cols
+        terminalMocks.latest.rows = terminalMocks.proposed.rows
+      }),
+      proposeDimensions: vi.fn(() => terminalMocks.proposed),
+      dispose: vi.fn(),
+    }
+  }),
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {}),
+}))
+
+function makeContainerRef() {
+  const container = document.createElement('div')
+  Object.defineProperty(container, 'offsetWidth', { value: 800 })
+  Object.defineProperty(container, 'offsetHeight', { value: 400 })
+  return { current: container }
+}
+
+function renderInit(onResize = vi.fn()) {
+  return renderHook(() =>
+    useTerminalInit({
+      terminalRef: { current: null } as never,
+      fitAddonRef: { current: null } as never,
+      disposedRef: { current: false },
+      containerRef: makeContainerRef() as never,
+      terminalId: 'term-1',
+      isActiveRef: { current: true },
+      isHiddenRef: { current: false },
+      scrollMachineRef: { current: { pendingWriteCount: 0, followOutputOnNextWrite: false, hiddenViewportIntent: null } } as never,
+      userViewportInteractingRef: { current: false },
+      viewportListenersRef: { current: null } as never,
+      scrollDisposableRef: { current: null } as never,
+      syncViewportState: vi.fn(),
+      clearUserViewportInteraction: vi.fn(),
+      markUserViewportInteraction: vi.fn(),
+      shouldSendEnhancedEnter: () => false,
+      attachClipboardListeners: vi.fn(),
+      getCtrlVHandler: () => () => undefined,
+      followLiveOutput: vi.fn(),
+      reconcileWebGL: vi.fn(),
+      syncFontAfterLoad: vi.fn(),
+      registerTerminalDebugHandle: vi.fn(),
+      onWriteParsed: vi.fn(),
+      onResize,
+    })
+  )
+}
+
+describe('useTerminalInit resize pipeline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('electron', {
+      terminal: {
+        resize: vi.fn(),
+        resizeHeadless: vi.fn(),
+        getSnapshot: vi.fn().mockResolvedValue({ data: '', cols: 0, rows: 0 }),
+      },
+      app: { openExternal: vi.fn() },
+    })
+    terminalMocks.latest = null
+    terminalMocks.latestOptions = null
+    terminalMocks.proposed = { cols: 120, rows: 30 }
+    terminalMocks.fitThrows = false
+    resetPtyResizeCoordinatorForTests()
+    resetTerminalOutputDispatcherForTests()
+    useAppStore.setState({ terminals: [] })
+  })
+
+  it('debounces xterm shrink and updates only headless cols in normal buffer', () => {
+    const onResize = vi.fn()
+    const { result } = renderInit(onResize)
+
+    act(() => result.current.initTerminal())
+    const resize = window.electron.terminal.resize as ReturnType<typeof vi.fn>
+    const resizeHeadless = window.electron.terminal.resizeHeadless as ReturnType<typeof vi.fn>
+    resize.mockClear()
+    resizeHeadless.mockClear()
+
+    act(() => {
+      terminalMocks.latest?.emitResize(40, 20)
+      vi.advanceTimersByTime(80)
+    })
+
+    expect(resize).not.toHaveBeenCalled()
+    expect(resizeHeadless).toHaveBeenCalledWith('term-1', 40, 20)
+    expect(onResize).toHaveBeenCalledWith(40, 20)
+  })
+
+  it('allows local cursor-line reflow so active input follows resize', () => {
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+
+    expect(terminalMocks.latestOptions?.windowsPty).toBeUndefined()
+    expect(terminalMocks.latestOptions?.reflowCursorLine).toBe(true)
+  })
+
+  it('disables cursor-line reflow for Claude normal-buffer input frames', () => {
+    useAppStore.setState({
+      terminals: [{ id: 'term-1', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+
+    expect(terminalMocks.latestOptions?.reflowCursorLine).toBe(false)
+  })
+
+  it('skips Claude normal-buffer PTY resize to prevent inline redraw duplication', () => {
+    useAppStore.setState({
+      terminals: [{ id: 'term-1', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    const onResize = vi.fn()
+    const { result } = renderInit(onResize)
+
+    act(() => result.current.initTerminal())
+    const resize = window.electron.terminal.resize as ReturnType<typeof vi.fn>
+    const resizeHeadless = window.electron.terminal.resizeHeadless as ReturnType<typeof vi.fn>
+    resize.mockClear()
+    resizeHeadless.mockClear()
+
+    act(() => {
+      terminalMocks.latest?.emitResize(40, 20)
+      vi.advanceTimersByTime(80)
+    })
+
+    expect(resize).not.toHaveBeenCalled()
+    expect(resizeHeadless).toHaveBeenCalledWith('term-1', 40, 20)
+    expect(onResize).toHaveBeenCalledWith(40, 20)
+  })
+
+  it('skips normal-buffer PTY resize when only agentType identifies Claude', () => {
+    useAppStore.setState({
+      terminals: [{
+        id: 'term-1',
+        title: 'Claude',
+        cwd: '/',
+        isClaudeMode: false,
+        agentType: 'claude',
+        createdAt: new Date().toISOString()
+      }] as never,
+    })
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+    const resize = window.electron.terminal.resize as ReturnType<typeof vi.fn>
+    resize.mockClear()
+
+    act(() => {
+      terminalMocks.latest?.emitResize(40, 20)
+      vi.advanceTimersByTime(80)
+    })
+
+    expect(resize).not.toHaveBeenCalled()
+  })
+
+  it('skips normal-buffer PTY resize when a Claude session id is already bound', () => {
+    useAppStore.setState({
+      terminals: [{
+        id: 'term-1',
+        title: 'Claude',
+        cwd: '/',
+        isClaudeMode: false,
+        claudeSessionId: 'session-123',
+        createdAt: new Date().toISOString()
+      }] as never,
+    })
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+    const resize = window.electron.terminal.resize as ReturnType<typeof vi.fn>
+    resize.mockClear()
+
+    act(() => {
+      terminalMocks.latest?.emitResize(40, 20)
+      vi.advanceTimersByTime(80)
+    })
+
+    expect(resize).not.toHaveBeenCalled()
+  })
+
+  it('still sends Claude alt-buffer PTY resize for full-screen TUIs', () => {
+    useAppStore.setState({
+      terminals: [{ id: 'term-1', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+    const resize = window.electron.terminal.resize as ReturnType<typeof vi.fn>
+    resize.mockClear()
+
+    act(() => {
+      if (terminalMocks.latest) terminalMocks.latest.buffer.active.type = 'alternate'
+      terminalMocks.latest?.emitResize(40, 20)
+      vi.advanceTimersByTime(80)
+    })
+
+    expect(resize).toHaveBeenCalledWith('term-1', 40, 20)
+  })
+
+  it('clamps initial fit below the safe width before syncing headless size', () => {
+    terminalMocks.proposed = { cols: 12, rows: 20 }
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+
+    expect(terminalMocks.latest?.resize).toHaveBeenCalledWith(MIN_SAFE_COLS, 20)
+    expect(window.electron.terminal.resize).not.toHaveBeenCalledWith('term-1', MIN_SAFE_COLS, 20)
+    expect(window.electron.terminal.resizeHeadless).toHaveBeenCalledWith('term-1', MIN_SAFE_COLS, 20)
+  })
+
+  it('continues terminal setup when the initial fit fails', () => {
+    terminalMocks.fitThrows = true
+    const { result } = renderInit()
+
+    act(() => result.current.initTerminal())
+
+    expect(terminalMocks.latest?.open).toHaveBeenCalled()
+    expect(terminalMocks.latest?.onResize).toHaveBeenCalled()
+    expect(window.electron.terminal.resize).not.toHaveBeenCalled()
+  })
+
+  it('does not replay buffered live output already covered by the init snapshot', async () => {
+    const getSnapshot = window.electron.terminal.getSnapshot as ReturnType<typeof vi.fn>
+    getSnapshot.mockResolvedValue({ data: 'welcome', cols: 120, rows: 30, byteOffset: 7 })
+
+    let publishOutput: ((payload: { terminalId: string; data: string; startOffset?: number; endOffset?: number }) => void) | null = null
+    attachTerminalOutputDispatcher((callback) => {
+      publishOutput = callback
+      return vi.fn()
+    })
+
+    const { result } = renderInit()
+    act(() => result.current.initTerminal())
+    registerTerminalOutputHandler('term-1', data => terminalMocks.latest?.write(data))
+
+    act(() => {
+      publishOutput?.({ terminalId: 'term-1', data: 'welcome', startOffset: 0, endOffset: 7 })
+    })
+    expect(terminalMocks.latest?.write).not.toHaveBeenCalledWith('welcome')
+
+    await act(async () => {
+      vi.advanceTimersByTime(50)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const snapshotWrites = terminalMocks.latest?.write.mock.calls
+      .filter(call => call[0] === 'welcome') ?? []
+
+    expect(snapshotWrites).toHaveLength(1)
+  })
+})

--- a/src/renderer/hooks/__tests__/use-terminal-resize-policy.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-resize-policy.spec.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Terminal as XTerm } from '@xterm/xterm'
+import type { ResizeColsChange } from '../use-terminal-fit'
+
+const mocks = vi.hoisted(() => ({
+  refreshTerminal: vi.fn(),
+  publishResizeEnd: vi.fn(),
+  capturedFitParams: null as {
+    terminalRef: { current: XTerm | null }
+    onResizeEnd?: (source: 'pane-drag' | 'window', colsChange: ResizeColsChange) => void
+  } | null,
+}))
+
+vi.mock('../use-terminal-webgl', () => ({
+  useTerminalWebGL: vi.fn(() => ({
+    reconcileWebGL: vi.fn(),
+    clearTextureAtlas: vi.fn(),
+    webglAddonRef: { current: null },
+    webglLoadingRef: { current: false },
+    reloadWebGLForTheme: vi.fn(),
+    refreshTerminal: mocks.refreshTerminal,
+  })),
+}))
+
+vi.mock('../use-terminal-fit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../use-terminal-fit')>()
+  return {
+    ...actual,
+    useTerminalFit: vi.fn((params: {
+      terminalRef: { current: XTerm | null }
+      onResizeEnd?: (source: 'pane-drag' | 'window', colsChange: ResizeColsChange) => void
+    }) => {
+      mocks.capturedFitParams = params
+      return {
+        performFit: vi.fn(() => true),
+        cancelScheduledFit: vi.fn(),
+        fit: vi.fn(),
+      }
+    }),
+  }
+})
+
+vi.mock('../../utils/terminal-resize-end-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/terminal-resize-end-dispatcher')>()
+  return { ...actual, publishResizeEnd: mocks.publishResizeEnd }
+})
+
+vi.mock('../use-terminal-debug', () => ({
+  useTerminalDebug: vi.fn(() => ({
+    registerTerminalDebugHandle: vi.fn(),
+    unregisterTerminalDebugHandle: vi.fn(),
+  })),
+}))
+
+vi.mock('../use-terminal-keyboard', () => ({
+  useTerminalKeyboard: vi.fn(() => ({
+    processKeyboardEnhancementOutput: vi.fn(),
+    shouldSendEnhancedEnter: vi.fn(() => false),
+  })),
+}))
+
+vi.mock('../use-terminal-scroll', () => ({
+  useTerminalScroll: vi.fn(() => ({
+    write: vi.fn(),
+    scrollToTop: vi.fn(),
+    scrollToBottom: vi.fn(),
+    followLiveOutput: vi.fn(),
+    syncViewportState: vi.fn(),
+    clearUserViewportInteraction: vi.fn(),
+    markUserViewportInteraction: vi.fn(),
+    onWriteParsed: vi.fn(),
+    isAtBottom: true,
+    hasScrollback: false,
+  })),
+}))
+
+vi.mock('../use-terminal-font-theme', () => ({
+  useTerminalFontTheme: vi.fn(() => ({ syncFontAfterLoad: vi.fn() })),
+}))
+
+vi.mock('../use-terminal-clipboard', () => ({
+  useTerminalClipboard: vi.fn(() => ({
+    attachClipboardListeners: vi.fn(),
+    getCtrlVHandler: vi.fn(),
+    followLiveOutputRef: { current: null },
+  })),
+}))
+
+vi.mock('../use-terminal-visibility', () => ({
+  useTerminalVisibility: vi.fn(),
+}))
+
+vi.mock('../use-terminal-scrollback', () => ({
+  useTerminalScrollback: vi.fn(),
+}))
+
+vi.mock('../use-terminal-init', () => ({
+  useTerminalInit: vi.fn(() => ({ initTerminal: vi.fn() })),
+}))
+
+import { useTerminal } from '../use-terminal'
+import { useAppStore } from '../../stores/app-store'
+
+function fakeTerminal(bufferType: 'normal' | 'alternate'): XTerm {
+  return {
+    cols: 80,
+    rows: 24,
+    buffer: { active: { type: bufferType, viewportY: 0, baseY: 0 } },
+    textarea: document.createElement('textarea'),
+    focus: vi.fn(),
+    blur: vi.fn(),
+    clear: vi.fn(),
+  } as unknown as XTerm
+}
+
+describe('useTerminal resize policy', () => {
+  beforeEach(() => {
+    mocks.refreshTerminal.mockClear()
+    mocks.publishResizeEnd.mockClear()
+    mocks.capturedFitParams = null
+    useAppStore.setState({ terminals: [] })
+  })
+
+  it('does not snapshot-replay a non-Claude normal-buffer prompt after pane resize-end', () => {
+    renderHook(() => useTerminal({ terminalId: 'term-1' }))
+    expect(mocks.capturedFitParams).not.toBeNull()
+
+    mocks.capturedFitParams!.terminalRef.current = fakeTerminal('normal')
+
+    act(() => {
+      mocks.capturedFitParams!.onResizeEnd?.('pane-drag', { changed: true, direction: 'wider' })
+    })
+
+    expect(mocks.publishResizeEnd).toHaveBeenCalledWith('term-1', 'pane-drag')
+    expect(mocks.refreshTerminal).not.toHaveBeenCalled()
+  })
+
+  it('snapshot-replays Claude normal-buffer after resize-end to repair xterm frame reflow', () => {
+    useAppStore.setState({
+      terminals: [{ id: 'term-1', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    renderHook(() => useTerminal({ terminalId: 'term-1' }))
+    expect(mocks.capturedFitParams).not.toBeNull()
+
+    mocks.capturedFitParams!.terminalRef.current = fakeTerminal('normal')
+
+    act(() => {
+      mocks.capturedFitParams!.onResizeEnd?.('pane-drag', { changed: true, direction: 'narrower' })
+    })
+
+    expect(mocks.publishResizeEnd).toHaveBeenCalledWith('term-1', 'pane-drag')
+    expect(mocks.refreshTerminal).toHaveBeenCalledWith(false, true)
+  })
+
+  it('does not snapshot-replay Claude normal-buffer when cols did not change', () => {
+    useAppStore.setState({
+      terminals: [{ id: 'term-1', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    renderHook(() => useTerminal({ terminalId: 'term-1' }))
+    expect(mocks.capturedFitParams).not.toBeNull()
+
+    mocks.capturedFitParams!.terminalRef.current = fakeTerminal('normal')
+
+    act(() => {
+      mocks.capturedFitParams!.onResizeEnd?.('pane-drag', { changed: false, direction: 'none' })
+    })
+
+    expect(mocks.refreshTerminal).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/__tests__/use-terminal-snapshot-refresh.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-snapshot-refresh.spec.ts
@@ -26,7 +26,8 @@ vi.mock('@xterm/addon-web-links')
 
 import { useTerminalWebGL } from '../use-terminal-webgl'
 import { pauseAndBuffer, resumeAndFlush, resetTerminalOutputDispatcherForTests } from '../../utils/terminal-output-dispatcher'
-import { useToastStore } from '../../stores'
+import { publishResizeEnd, resetResizeEndDispatcherForTests } from '../../utils/terminal-resize-end-dispatcher'
+import { useAppStore, useToastStore } from '../../stores'
 
 // ── xterm mock helpers ──────────────────────────────────────────────────────
 
@@ -41,17 +42,25 @@ const extendedMock = mockTerminalInstance as typeof mockTerminalInstance & {
   refresh: ReturnType<typeof vi.fn>
 }
 
+function setMockBufferType(type: 'normal' | 'alternate'): void {
+  ;(extendedMock.buffer.active as typeof extendedMock.buffer.active & { type: 'normal' | 'alternate' }).type = type
+}
+
 // ── window.electron helpers ─────────────────────────────────────────────────
 
 type ElectronTerminalMock = {
   getSnapshot: ReturnType<typeof vi.fn>
+  rebuildHeadless: ReturnType<typeof vi.fn>
   resize: ReturnType<typeof vi.fn>
+  resizeHeadless: ReturnType<typeof vi.fn>
 }
 
 function stubElectronTerminal(overrides: Partial<ElectronTerminalMock> = {}) {
   const mock: ElectronTerminalMock = {
     getSnapshot: vi.fn().mockResolvedValue({ data: '\x1b[2Jhello', cols: 80, rows: 24 }),
+    rebuildHeadless: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn(),
+    resizeHeadless: vi.fn(),
     ...overrides,
   }
   vi.stubGlobal('electron', {
@@ -97,15 +106,19 @@ beforeEach(() => {
   extendedMock.resize = extendedMock.resize ?? vi.fn()
   extendedMock.clearTextureAtlas = extendedMock.clearTextureAtlas ?? vi.fn()
   extendedMock.refresh = extendedMock.refresh ?? vi.fn()
+  setMockBufferType('normal')
 
   // Reset all mock call counts
   vi.clearAllMocks()
   resetTerminalOutputDispatcherForTests()
+  resetResizeEndDispatcherForTests()
+  useAppStore.setState({ terminals: [] })
 
   stubElectronTerminal()
 })
 
 afterEach(() => {
+  resetResizeEndDispatcherForTests()
   vi.useRealTimers()
   vi.unstubAllGlobals()
 })
@@ -176,7 +189,63 @@ describe('refreshTerminal with snapshot replay', () => {
     expect(altBufIdx).toBeLessThan(snapIdx)
   })
 
-  it('sends SIGWINCH (electron resize) after snapshot write', async () => {
+  it('preserves alt-buffer when requested by automatic resize refresh', async () => {
+    const mockSnap = { data: 'snap-content', cols: 80, rows: 24 }
+    stubElectronTerminal({ getSnapshot: vi.fn().mockResolvedValue(mockSnap) })
+
+    const { refreshTerminal } = renderWebGL()
+
+    await act(async () => {
+      refreshTerminal(false, true)
+      vi.runAllTimers()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const writeCalls = (extendedMock.write as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+
+    expect(writeCalls).not.toContain('\x1b[?1049l')
+    expect(writeCalls).toContain('snap-content')
+  })
+
+  it('does not run snapshot replay for non-Claude split resize-end events', () => {
+    const electronMock = stubElectronTerminal()
+
+    renderWebGL()
+
+    act(() => {
+      publishResizeEnd('test-term', 'split')
+    })
+
+    expect(electronMock.rebuildHeadless).not.toHaveBeenCalled()
+    expect(electronMock.getSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('snapshot-replays Claude normal-buffer after split resize-end', async () => {
+    const electronMock = stubElectronTerminal()
+    useAppStore.setState({
+      terminals: [{ id: 'test-term', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    setMockBufferType('normal')
+
+    renderWebGL()
+
+    await act(async () => {
+      publishResizeEnd('test-term', 'split')
+      vi.runAllTimers()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(electronMock.rebuildHeadless).toHaveBeenCalledWith('test-term')
+    expect(electronMock.getSnapshot).toHaveBeenCalledWith('test-term')
+    expect(electronMock.resize).not.toHaveBeenCalled()
+    expect(electronMock.resizeHeadless).toHaveBeenCalledWith('test-term', expect.any(Number), expect.any(Number))
+  })
+
+  it('syncs only headless size after normal-buffer snapshot write', async () => {
     const electronMock = stubElectronTerminal()
 
     const { refreshTerminal } = renderWebGL()
@@ -189,7 +258,57 @@ describe('refreshTerminal with snapshot replay', () => {
       await Promise.resolve()
     })
 
-    expect(electronMock.resize).toHaveBeenCalledWith('test-term', expect.any(Number), expect.any(Number))
+    expect(electronMock.resize).not.toHaveBeenCalled()
+    expect(electronMock.resizeHeadless).toHaveBeenCalledWith('test-term', expect.any(Number), expect.any(Number))
+  })
+
+  it('does not send SIGWINCH after snapshot replay for Claude normal-buffer', async () => {
+    const electronMock = stubElectronTerminal()
+    useAppStore.setState({
+      terminals: [{ id: 'test-term', title: 'Claude', cwd: '/', isClaudeMode: true, createdAt: new Date().toISOString() }] as never,
+    })
+    setMockBufferType('normal')
+
+    const { refreshTerminal } = renderWebGL()
+
+    await act(async () => {
+      refreshTerminal(false, true)
+      vi.runAllTimers()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(electronMock.resize).not.toHaveBeenCalled()
+    expect(electronMock.resizeHeadless).toHaveBeenCalledWith('test-term', expect.any(Number), expect.any(Number))
+  })
+
+  it('does not send SIGWINCH after snapshot replay when only agentType identifies Claude', async () => {
+    const electronMock = stubElectronTerminal()
+    useAppStore.setState({
+      terminals: [{
+        id: 'test-term',
+        title: 'Claude',
+        cwd: '/',
+        isClaudeMode: false,
+        agentType: 'claude',
+        createdAt: new Date().toISOString()
+      }] as never,
+    })
+    setMockBufferType('normal')
+
+    const { refreshTerminal } = renderWebGL()
+
+    await act(async () => {
+      refreshTerminal(false, true)
+      vi.runAllTimers()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(electronMock.resize).not.toHaveBeenCalled()
+    expect(electronMock.resizeHeadless).toHaveBeenCalledWith('test-term', expect.any(Number), expect.any(Number))
   })
 
   it('shows success toast on normal refresh', async () => {
@@ -245,7 +364,7 @@ describe('refreshTerminal with snapshot replay', () => {
     expect(addToastSpy).toHaveBeenCalledWith(expect.stringContaining('error'), 'error')
   })
 
-  it('handles empty snapshot gracefully — no reset crash, still SIGWINCH', async () => {
+  it('handles empty snapshot gracefully and still syncs headless size', async () => {
     const electronMock = stubElectronTerminal({
       getSnapshot: vi.fn().mockResolvedValue({ data: '', cols: 0, rows: 0 }),
     })
@@ -263,8 +382,8 @@ describe('refreshTerminal with snapshot replay', () => {
       }).not.toThrow()
     })
 
-    // SIGWINCH still expected even with empty snapshot
-    expect(electronMock.resize).toHaveBeenCalled()
+    expect(electronMock.resize).not.toHaveBeenCalled()
+    expect(electronMock.resizeHeadless).toHaveBeenCalled()
   })
 
   it('mutex: rapid double-trigger → only one replay executes', async () => {

--- a/src/renderer/hooks/use-execute-split.ts
+++ b/src/renderer/hooks/use-execute-split.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react'
 import type { PaneSplitDirection, ShellInfo, Terminal, WindowsShell } from '@shared/types'
 import { beginRendererCreate } from '../utils/renderer-create-tracker'
-import { publishResizeEnd } from '../utils/terminal-resize-end-dispatcher'
+import { publishResizeEnd, suppressAutoResizeRefresh } from '../utils/terminal-resize-end-dispatcher'
 import { closeLeafAndCollapse, findLeaf, splitLeaf } from '@shared/utils/pane-tree'
 import { usePaneTreeStore } from '../stores/pane-tree-store'
 
@@ -152,6 +152,8 @@ export function useExecuteSplit(deps: ExecuteSplitDeps): {
 
       addTerminal(terminal)
 
+      let resizedSourceTerminalId = sourceTerminalId
+
       if (projectId) {
         const currentTree = usePaneTreeStore.getState().getTree(projectId)
         if (currentTree) {
@@ -172,6 +174,7 @@ export function useExecuteSplit(deps: ExecuteSplitDeps): {
             // preserve user's direction intent by splitting the active pane
             // and tell them the source is gone.
             notifyError('Source pane was closed — splitting active pane instead')
+            resizedSourceTerminalId = activeTerminalId
             usePaneTreeStore
               .getState()
               .setTree(projectId, splitLeaf(cleaned, activeTerminalId, direction, terminal.id))
@@ -185,11 +188,13 @@ export function useExecuteSplit(deps: ExecuteSplitDeps): {
       // setTree call (the very race this counter exists to defend against).
       releaseRendererCreate()
 
-      // Phase 01 alt-buffer repaint: split shrinks the source pane via React
+      suppressAutoResizeRefresh(resizedSourceTerminalId)
+
+      // Split resize repaint: split shrinks the source pane via React
       // re-render → ResizeObserver → fit. Wait for layout/SIGWINCH to settle
       // (~250ms), then publish so the source pane's alt-screen TUI repaints
       // at the new width. New pane has nothing to repaint yet (PTY just spawned).
-      setTimeout(() => publishResizeEnd(sourceTerminalId), 300)
+      setTimeout(() => publishResizeEnd(resizedSourceTerminalId, 'split'), 300)
     },
     [
       activeTerminalId,

--- a/src/renderer/hooks/use-execute-split.ts
+++ b/src/renderer/hooks/use-execute-split.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 import type { PaneSplitDirection, ShellInfo, Terminal, WindowsShell } from '@shared/types'
 import { beginRendererCreate } from '../utils/renderer-create-tracker'
+import { publishResizeEnd } from '../utils/terminal-resize-end-dispatcher'
 import { closeLeafAndCollapse, findLeaf, splitLeaf } from '@shared/utils/pane-tree'
 import { usePaneTreeStore } from '../stores/pane-tree-store'
 
@@ -183,6 +184,12 @@ export function useExecuteSplit(deps: ExecuteSplitDeps): {
       // sees us as in-flight if it fires between the IPC return and our
       // setTree call (the very race this counter exists to defend against).
       releaseRendererCreate()
+
+      // Phase 01 alt-buffer repaint: split shrinks the source pane via React
+      // re-render → ResizeObserver → fit. Wait for layout/SIGWINCH to settle
+      // (~250ms), then publish so the source pane's alt-screen TUI repaints
+      // at the new width. New pane has nothing to repaint yet (PTY just spawned).
+      setTimeout(() => publishResizeEnd(sourceTerminalId), 300)
     },
     [
       activeTerminalId,

--- a/src/renderer/hooks/use-pane-resize.ts
+++ b/src/renderer/hooks/use-pane-resize.ts
@@ -156,8 +156,10 @@ export function usePaneResize({
         } catch {
           // ignore
         }
-        setPaneDragging(false)
         cleanupRef.current = null
+        requestAnimationFrame(() => {
+          if (cleanupRef.current === null) setPaneDragging(false)
+        })
       }
 
       const onEnd = (): void => cleanup()

--- a/src/renderer/hooks/use-terminal-fit.ts
+++ b/src/renderer/hooks/use-terminal-fit.ts
@@ -44,6 +44,11 @@ interface UseTerminalFitParams {
    * to rebuild the display from the raw PTY transcript at the new width.
    */
   onColsChanged?: () => void
+  /**
+   * Fired on the trailing edge of a resize gesture (drag-end / window-resize-end).
+   * Used to trigger alt-buffer repaint after layout settles.
+   */
+  onResizeEnd?: () => void
 }
 
 interface UseTerminalFitResult {
@@ -61,7 +66,12 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
     scrollMachineRef,
     refreshVisibleRows,
     onColsChanged,
+    onResizeEnd,
   } = params
+
+  // Stable ref so handlers always see the latest onResizeEnd without stale closure
+  const onResizeEndRef = useRef(onResizeEnd)
+  onResizeEndRef.current = onResizeEnd
 
   const fitAnimationFrameRef = useRef<number | null>(null)
   const fitSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -235,9 +245,21 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
   }, [containerRef, fit])
 
   useEffect(() => {
-    const h = () => fit()
+    let trailingTimer: ReturnType<typeof setTimeout> | null = null
+    const h = () => {
+      fit()
+      // Trailing-edge resize-end: fires once window stops resizing for 250ms
+      if (trailingTimer) clearTimeout(trailingTimer)
+      trailingTimer = setTimeout(() => {
+        trailingTimer = null
+        onResizeEndRef.current?.()
+      }, 250)
+    }
     window.addEventListener('resize', h)
-    return () => window.removeEventListener('resize', h)
+    return () => {
+      window.removeEventListener('resize', h)
+      if (trailingTimer) clearTimeout(trailingTimer)
+    }
   }, [fit])
 
   // When drag starts, cancel any already-scheduled fit so it can't fire
@@ -252,6 +274,8 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
       if (!fitPendingDuringDragRef.current) return
       fitPendingDuringDragRef.current = false
       fit()
+      // Fire resize-end after fit settle (RESIZE_REFIT_SETTLE_DELAY=120ms + margin)
+      setTimeout(() => onResizeEndRef.current?.(), RESIZE_REFIT_SETTLE_DELAY + 80)
     })
   }, [cancelScheduledFit, fit])
 

--- a/src/renderer/hooks/use-terminal-fit.ts
+++ b/src/renderer/hooks/use-terminal-fit.ts
@@ -17,21 +17,50 @@ import type { TerminalScrollMachine } from '../utils/terminal-scroll-machine'
 import { resolveFitViewportRestoreTarget } from '../utils/terminal-scroll-utils'
 import { isPaneDragging, subscribePaneDragging } from '../utils/pane-drag-state'
 import { useSettingsStore } from '../stores'
+import { isAutoResizeRefreshSuppressed } from '../utils/terminal-resize-end-dispatcher'
 
 // Part D: debounce before triggering silent snapshot replay on cols change
 const REFLOW_SAFE_COLS_CHANGE_DEBOUNCE = 300 // ms
 
 const RESIZE_REFIT_SETTLE_DELAY = 120  // ms second fit after layout settles
 const FIT_RETRY_WHEN_HIDDEN_DELAY = 120  // ms retry when container briefly has 0 size
+const PANE_RESIZE_END_DEBOUNCE = 320 // ms after the last post-drag fit
 
-// xterm's buffer reflow corrupts at very narrow widths — rows get split into
-// character-per-line stretched blocks that orphan in scrollback after the
-// user drags the pane back wider. Skip fit if proposed cols would go below
-// this floor; the pane stays visually narrow but the terminal keeps its
-// previous cols (content clips on the right, but re-opens intact).
-const MIN_SAFE_COLS = 20
+// xterm's normal-buffer reflow becomes unreadable at very narrow widths,
+// especially with prompts that include right-aligned segments or table-like
+// output. Below this floor we clip the pane instead of letting xterm rewrite
+// the active line into scattered one-character wraps.
+export const MIN_SAFE_COLS = 20
+
+export type ResizeColsDirection = 'none' | 'narrower' | 'wider'
+export interface ResizeColsChange {
+  changed: boolean
+  direction: ResizeColsDirection
+}
+
+const NO_COLS_CHANGE: ResizeColsChange = { changed: false, direction: 'none' }
+
+export function fitTerminalSafely(terminal: XTerm, fitAddon: FitAddon): boolean {
+  const proposed = fitAddon.proposeDimensions()
+  if (proposed && proposed.cols < MIN_SAFE_COLS) {
+    try {
+      terminal.resize(MIN_SAFE_COLS, Math.max(1, proposed.rows))
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  try {
+    fitAddon.fit()
+    return true
+  } catch {
+    return false
+  }
+}
 
 interface UseTerminalFitParams {
+  terminalId: string
   terminalRef: RefObject<XTerm | null>
   fitAddonRef: RefObject<FitAddon | null>
   containerRef: RefObject<HTMLDivElement | null>
@@ -48,7 +77,7 @@ interface UseTerminalFitParams {
    * Fired on the trailing edge of a resize gesture (drag-end / window-resize-end).
    * Used to trigger alt-buffer repaint after layout settles.
    */
-  onResizeEnd?: () => void
+  onResizeEnd?: (source: 'pane-drag' | 'window', colsChange: ResizeColsChange) => void
 }
 
 interface UseTerminalFitResult {
@@ -59,6 +88,7 @@ interface UseTerminalFitResult {
 
 export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResult {
   const {
+    terminalId,
     terminalRef,
     fitAddonRef,
     containerRef,
@@ -82,6 +112,20 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
   onColsChangedRef.current = onColsChanged
 
   const lastFitDimsRef = useRef<{ cols: number; rows: number } | null>(null)
+  const colsChangeSinceResizeEndRef = useRef<ResizeColsChange>(NO_COLS_CHANGE)
+  const paneResizeEndPendingRef = useRef(false)
+  const paneResizeEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const schedulePaneResizeEnd = useCallback(() => {
+    if (paneResizeEndTimerRef.current) clearTimeout(paneResizeEndTimerRef.current)
+    paneResizeEndTimerRef.current = setTimeout(() => {
+      paneResizeEndTimerRef.current = null
+      paneResizeEndPendingRef.current = false
+      const colsChange = colsChangeSinceResizeEndRef.current
+      colsChangeSinceResizeEndRef.current = NO_COLS_CHANGE
+      onResizeEndRef.current?.('pane-drag', colsChange)
+    }, PANE_RESIZE_END_DEBOUNCE)
+  }, [])
 
   const performFit = useCallback((restoreViewport = true) => {
     const terminal = terminalRef.current
@@ -99,16 +143,11 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
     // that would always fire onColsChanged even when the terminal hasn't been resized.
     const isFirstFit = lastFitDimsRef.current === null
 
-    // Skip fit when proposed cols would corrupt xterm reflow.
-    const proposed = fitAddon.proposeDimensions()
-    if (proposed && proposed.cols < MIN_SAFE_COLS) return false
-
-    try {
-      fitAddon.fit()
-    } catch {
-      return false
-    }
-
+    // Clamp fits that would corrupt xterm reflow. Calling terminal.resize()
+    // still emits xterm's resize event, so the debounced PTY resize path can
+    // sync $COLUMNS to the safe floor instead of leaving it at a stale wide
+    // value from before the pane was narrowed.
+    if (!fitTerminalSafely(terminal, fitAddon)) return false
     lastFitDimsRef.current = { cols: terminal.cols, rows: terminal.rows }
 
     // Part D: if cols changed and reflowSafeScrollback is enabled, debounce a silent
@@ -116,17 +155,31 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
     // The debounce resets on every performFit call while the user is still dragging —
     // the actual replay only fires when the width stabilises.
     // I3: Skip on first fit (mount) — prevCols is the xterm default, not a real resize.
-    if (!isFirstFit && terminal.cols !== prevCols && onColsChangedRef.current) {
+    const colsChanged = !isFirstFit && terminal.cols !== prevCols
+    const colsDirection: ResizeColsDirection = colsChanged
+      ? terminal.cols > prevCols ? 'wider' : 'narrower'
+      : 'none'
+    if (colsChanged) {
+      colsChangeSinceResizeEndRef.current = { changed: true, direction: colsDirection }
+    }
+    if (paneResizeEndPendingRef.current) schedulePaneResizeEnd()
+    const paneDragResizeSettling = paneResizeEndPendingRef.current || isPaneDragging()
+    if (colsChanged && !paneDragResizeSettling && onColsChangedRef.current) {
       // Read savedSettings (persisted source of truth) so toggling the switch
       // in the modal doesn't activate the behaviour until the user clicks Save.
       const reflowEnabled =
         useSettingsStore.getState().savedSettings.reflowSafeScrollback === true
       if (reflowEnabled) {
+        const wasSuppressedWhenScheduled = isAutoResizeRefreshSuppressed(terminalId)
         if (reflowSafeDebounceRef.current) clearTimeout(reflowSafeDebounceRef.current)
         reflowSafeDebounceRef.current = setTimeout(() => {
           reflowSafeDebounceRef.current = null
           // Re-check at fire time — user may have disabled it during debounce window.
-          if (useSettingsStore.getState().savedSettings.reflowSafeScrollback === true) {
+          if (
+            useSettingsStore.getState().savedSettings.reflowSafeScrollback === true &&
+            !wasSuppressedWhenScheduled &&
+            !isAutoResizeRefreshSuppressed(terminalId)
+          ) {
             onColsChangedRef.current?.()
           }
         }, REFLOW_SAFE_COLS_CHANGE_DEBOUNCE)
@@ -146,7 +199,7 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
     else if (typeof restoreTarget === 'number') terminalRef.current?.scrollToLine(restoreTarget)
 
     return true
-  }, [containerRef, disposedRef, fitAddonRef, refreshVisibleRows, scrollMachineRef, terminalRef])
+  }, [containerRef, disposedRef, fitAddonRef, refreshVisibleRows, schedulePaneResizeEnd, scrollMachineRef, terminalId, terminalRef])
 
   const cancelScheduledFit = useCallback(() => {
     if (fitAnimationFrameRef.current !== null) {
@@ -159,24 +212,34 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
     }
   }, [])
 
-  // Defer fit() while a pane divider is being dragged. xterm's internal
-  // reflow at rapidly-changing cols leaves wrapped rows orphaned in
-  // scrollback — duplicated banners, character-per-line stretched blocks.
-  // Gate fit on drag state: mark pending, flush on drag end.
+  // Keep xterm responsive while dragging, but leave PTY SIGWINCH gating to
+  // pty-resize-coordinator. This gives Warp-like live pane sizing without
+  // asking normal-buffer shells/agents to redraw into scrollback.
   const fitPendingDuringDragRef = useRef(false)
 
   const fit = useCallback(() => {
     if (disposedRef.current) return
     if (isPaneDragging()) {
       fitPendingDuringDragRef.current = true
+      cancelScheduledFit()
+      fitAnimationFrameRef.current = requestAnimationFrame(() => {
+        fitAnimationFrameRef.current = null
+        if (!isPaneDragging()) {
+          performFit(false)
+          return
+        }
+        performFit(false)
+      })
       return
     }
     cancelScheduledFit()
     fitAnimationFrameRef.current = requestAnimationFrame(() => {
       fitAnimationFrameRef.current = null
-      // Drag may have started between fit() call and rAF firing — defer.
+      // Drag may have started between fit() call and rAF firing — switch to
+      // responsive drag fit instead of running the normal settle path.
       if (isPaneDragging()) {
         fitPendingDuringDragRef.current = true
+        performFit(false)
         return
       }
       // If performFit returned false because the container was 0×0 (pane
@@ -252,7 +315,9 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
       if (trailingTimer) clearTimeout(trailingTimer)
       trailingTimer = setTimeout(() => {
         trailingTimer = null
-        onResizeEndRef.current?.()
+        const colsChange = colsChangeSinceResizeEndRef.current
+        colsChangeSinceResizeEndRef.current = NO_COLS_CHANGE
+        onResizeEndRef.current?.('window', colsChange)
       }, 250)
     }
     window.addEventListener('resize', h)
@@ -273,11 +338,11 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
       }
       if (!fitPendingDuringDragRef.current) return
       fitPendingDuringDragRef.current = false
+      paneResizeEndPendingRef.current = true
       fit()
-      // Fire resize-end after fit settle (RESIZE_REFIT_SETTLE_DELAY=120ms + margin)
-      setTimeout(() => onResizeEndRef.current?.(), RESIZE_REFIT_SETTLE_DELAY + 80)
+      schedulePaneResizeEnd()
     })
-  }, [cancelScheduledFit, fit])
+  }, [cancelScheduledFit, fit, schedulePaneResizeEnd])
 
   // Part D: clean up reflow-safe debounce timer on unmount
   useEffect(() => {
@@ -286,6 +351,11 @@ export function useTerminalFit(params: UseTerminalFitParams): UseTerminalFitResu
         clearTimeout(reflowSafeDebounceRef.current)
         reflowSafeDebounceRef.current = null
       }
+      if (paneResizeEndTimerRef.current) {
+        clearTimeout(paneResizeEndTimerRef.current)
+        paneResizeEndTimerRef.current = null
+      }
+      paneResizeEndPendingRef.current = false
     }
   }, [])
 

--- a/src/renderer/hooks/use-terminal-init.ts
+++ b/src/renderer/hooks/use-terminal-init.ts
@@ -31,10 +31,14 @@ import {
 import { stripLeakedTerminalResponses } from '../utils/terminal-output-utils'
 import { pauseAndBuffer, resumeAndFlush } from '../utils/terminal-output-dispatcher'
 import { useSettingsStore, useToastStore, useImageStore } from '../stores'
+import { isClaudeLikeTerminalId } from '../stores/app-store'
 import { getTerminalFontFamilyById, isAllowedExternalUrl, SCROLLBACK_DEFAULT, SCROLLBACK_MIN, SCROLLBACK_MAX } from '@shared/constants'
 import { shouldBypassXtermShortcut } from '../utils'
 import { getCsiUEnterSequence } from '../utils/keyboard-enhancement-utils'
 import { getCurrentTerminalTheme } from './use-terminal-font-theme'
+import { logResize } from '../utils/terminal-resize-debug'
+import { sendPtyResize } from '../utils/pty-resize-coordinator'
+import { fitTerminalSafely } from './use-terminal-fit'
 
 const TERMINAL_INIT_DELAY = 50         // ms after terminal.open() before loading addons
 const TERMINAL_MIN_CONTRAST_RATIO = 2.0
@@ -47,7 +51,6 @@ export function clampScrollback(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return SCROLLBACK_DEFAULT
   return Math.min(SCROLLBACK_MAX, Math.max(SCROLLBACK_MIN, Math.floor(value)))
 }
-
 
 interface ViewportEventListener {
   target: EventTarget
@@ -157,7 +160,10 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
       allowProposedApi: true,
       convertEol: false,
       scrollback: clampScrollback(useSettingsStore.getState().pendingSettings.scrollbackLines),
-      reflowCursorLine: true,   // v6: include cursor line in reflow on resize
+      // Claude draws an inline input frame in the normal buffer. Since
+      // normal-buffer SIGWINCH is suppressed to avoid duplicate frames, xterm
+      // must not reflow Claude's active cursor line on its own.
+      reflowCursorLine: !isClaudeLikeTerminalId(terminalId),
       // OSC 8 hyperlinks: CLIs (e.g. Claude Code) emit explicit hyperlink metadata
       // that survives line-wrapping. Without this handler, clicks fall back to
       // WebLinksAddon regex scanning wrapped buffer text — which can miss the tail
@@ -179,19 +185,25 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
 
     terminal.open(container)
 
-    // Sync fit + PTY resize BEFORE any shell output is written. Moving this out
-    // of the deferred setTimeout eliminates the new-pane jump: without it, the
-    // shell prints its first prompt at xterm's default 80×24, then we fit +
-    // SIGWINCH 50ms later and the shell redraws the prompt at the real size
-    // (visible 1–2 line dip). Doing it synchronously means the SIGWINCH fires
-    // while the shell is still spawning, so the first prompt is rendered once
-    // at the final cols/rows. Snapshot fetch below then reflects post-SIGWINCH
-    // state, avoiding a second redraw cycle when we paint into xterm.
+    // Fit xterm synchronously before snapshot paint. Normal-buffer panes sync
+    // only the headless mirror; shells/agents must not redraw already-captured
+    // prompt or frame content into scrollback.
     try {
-      fitAddon.fit()
-      window.electron.terminal.resize(terminalId, terminal.cols, terminal.rows)
+      if (fitTerminalSafely(terminal, fitAddon)) {
+        logResize('ipc', terminalId, {
+          phase: 'sync-initial-size',
+          cols: terminal.cols, rows: terminal.rows,
+        })
+        sendPtyResize({
+          terminalId,
+          xtermCols: terminal.cols,
+          rows: terminal.rows,
+          isAlt: terminal.buffer.active.type === 'alternate',
+          isClaudeMode: isClaudeLikeTerminalId(terminalId),
+        })
+      }
     } catch {
-      // Container briefly 0×0 — deferred setTimeout path will retry via fitAddon.fit()
+      // Container briefly 0×0 — deferred setTimeout path will retry via safe fit.
     }
 
     // xterm v6 removed the v5 auto-sync of .xterm-viewport background-color.
@@ -299,7 +311,7 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
       reconcileWebGL()
 
       try {
-        fitAddon.fit()
+        fitTerminalSafely(terminal, fitAddon)
       } catch {
         // Ignore fit errors during early init
       }
@@ -338,13 +350,13 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
           if (snap.data) {
             terminal.write(snap.data, () => {
               requestAnimationFrame(restoreInitialViewport)
-              finishInit()
+              resumeAndFlush(terminalId, { afterOffset: snap.byteOffset })
             })
           } else {
             // Empty snapshot (fresh terminal) — restore viewport; SIGWINCH
             // already sent by the sync resize IPC at open() time.
             requestAnimationFrame(restoreInitialViewport)
-            finishInit()
+            resumeAndFlush(terminalId, { afterOffset: snap.byteOffset })
           }
         }).catch(() => {
           // Snapshot fetch failed — fall back to viewport restore.
@@ -436,9 +448,29 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
       if (!pendingResize) return
       const { cols, rows } = pendingResize
       pendingResize = null
-      if (lastSent && lastSent.cols === cols && lastSent.rows === rows) return
-      lastSent = { cols, rows }
-      window.electron.terminal.resize(terminalId, cols, rows)
+
+      if (lastSent && lastSent.cols === cols && lastSent.rows === rows) {
+        logResize('ipc', terminalId, { phase: 'dedup', cols, rows })
+        return
+      }
+      const isAlt = terminal.buffer.active.type === 'alternate'
+      const prevSent = lastSent
+      const { sentCols, decoupled, skipped } = sendPtyResize({
+        terminalId,
+        xtermCols: cols,
+        rows,
+        isAlt,
+        isClaudeMode: isClaudeLikeTerminalId(terminalId),
+      })
+      if (!skipped) lastSent = { cols: sentCols, rows }
+      logResize('ipc', terminalId, {
+        phase: skipped ? 'sync-headless-normal-buffer' : 'send-sigwinch',
+        cols: sentCols, rows,
+        xtermCols: cols,
+        isAlt,
+        decoupled,
+        prev: prevSent ? `${prevSent.cols}x${prevSent.rows}` : 'none',
+      })
       onResize?.(cols, rows)
     }
     terminal.onResize(({ cols, rows }) => {

--- a/src/renderer/hooks/use-terminal-keyboard.ts
+++ b/src/renderer/hooks/use-terminal-keyboard.ts
@@ -13,6 +13,7 @@ import { useCallback, useRef } from 'react'
 import type { RefObject } from 'react'
 import type { Terminal as XTerm } from '@xterm/xterm'
 import { useAppStore } from '../stores'
+import { isClaudeLikeTerminalId } from '../stores/app-store'
 import {
   INITIAL_KEYBOARD_ENHANCEMENT_STATE,
   isTerminalKeyboardEnhancementEnabled,
@@ -73,9 +74,7 @@ export function useTerminalKeyboard(params: UseTerminalKeyboardParams): UseTermi
   const shouldSendEnhancedEnter = useCallback(() => {
     if (isTerminalKeyboardEnhancementEnabled(keyboardEnhancementStateRef.current)) return true
 
-    return useAppStore.getState().terminals.some(
-      terminal => terminal.id === terminalId && terminal.isClaudeMode
-    )
+    return isClaudeLikeTerminalId(terminalId)
   }, [terminalId])
 
   return { processKeyboardEnhancementOutput, shouldSendEnhancedEnter, keyboardEnhancementStateRef }

--- a/src/renderer/hooks/use-terminal-webgl.ts
+++ b/src/renderer/hooks/use-terminal-webgl.ts
@@ -18,6 +18,8 @@ import type { Terminal as XTerm } from '@xterm/xterm'
 import { useSettingsStore, useAppStore, useToastStore } from '../stores'
 import { pauseAndBuffer, resumeAndFlush } from '../utils/terminal-output-dispatcher'
 import { subscribeToSystemResume, unsubscribeFromSystemResume } from '../utils/terminal-lifecycle-dispatcher'
+import { subscribeToResizeEnd, unsubscribeFromResizeEnd } from '../utils/terminal-resize-end-dispatcher'
+import { triggerAltBufferRepaint, isResizeRepaintEnabled } from '../utils/trigger-alt-buffer-repaint'
 
 // ── Per-terminal mutex ───────────────────────────────────────────────────────
 // Prevents concurrent snapshot replays (e.g. refresh + phase-4 auto-resync).
@@ -429,6 +431,19 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
     reconcileWebGL,
     performFit,
   ])
+
+  // Phase 01: subscribe to resize-end events (drag-end, window-resize-end, split-end).
+  // Forces alt-screen TUIs to fully repaint after layout settles. Skips if a snapshot
+  // replay is already in flight (system-resume race) — that replay fires its own SIGWINCH.
+  useEffect(() => {
+    if (!isResizeRepaintEnabled()) return
+    subscribeToResizeEnd(terminalId, () => {
+      if (disposedRef.current || !terminalRef.current) return
+      if (snapshotReplayMutex.has(terminalId)) return  // R3: skip during replay
+      triggerAltBufferRepaint(terminalId, terminalRef.current)
+    })
+    return () => unsubscribeFromResizeEnd(terminalId)
+  }, [terminalId, terminalRef, disposedRef])
 
   return { reconcileWebGL, clearTextureAtlas, webglAddonRef, webglLoadingRef, reloadWebGLForTheme, refreshTerminal }
 }

--- a/src/renderer/hooks/use-terminal-webgl.ts
+++ b/src/renderer/hooks/use-terminal-webgl.ts
@@ -94,6 +94,13 @@ interface SnapshotReplayParams {
   reconcileWebGL: () => void
   performFit: (restoreViewport?: boolean) => boolean
   silent: boolean
+  /**
+   * Phase 02: When true, skip the `\x1b[?1049l` alt-buffer-exit write at line 162.
+   * Use for resize-end replays where the user is still mid-vim/Claude-TUI session
+   * and should remain in alt-buffer. Default false (current behavior — system-resume
+   * replay kicks out of alt-buffer so user sees shell prompt after lid-wake).
+   */
+  preserveAltBuffer?: boolean
 }
 
 /**
@@ -119,6 +126,7 @@ export async function performSnapshotReplay(params: SnapshotReplayParams): Promi
     reconcileWebGL,
     performFit,
     silent,
+    preserveAltBuffer,
   } = params
 
   // H6: concurrent refresh + auto-resync guard
@@ -161,7 +169,11 @@ export async function performSnapshotReplay(params: SnapshotReplayParams): Promi
 
     // B1: force exit alt-buffer before replaying snapshot — ensures shell prompt
     // is visible even if terminal was inside vim/less when refresh was triggered.
-    t.write('\x1b[?1049l', undefined)
+    // Phase 02: skip when caller passes preserveAltBuffer (resize-end replay path
+    // should keep user inside vim/Claude TUI).
+    if (!preserveAltBuffer) {
+      t.write('\x1b[?1049l', undefined)
+    }
 
     // Apply snapshot dimensions if valid
     if (snap.cols > 0 && snap.rows > 0) {
@@ -417,6 +429,9 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
         reconcileWebGL,
         performFit,
         silent: true,
+        // Phase 02: don't kick user out of alt-buffer on lid-wake (vim/Claude TUI).
+        // Refresh button path stays default (false) — explicit user action implies reset intent.
+        preserveAltBuffer: true,
       })
     })
     return () => unsubscribeFromSystemResume(terminalId)

--- a/src/renderer/hooks/use-terminal-webgl.ts
+++ b/src/renderer/hooks/use-terminal-webgl.ts
@@ -16,10 +16,12 @@ import type { RefObject } from 'react'
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { Terminal as XTerm } from '@xterm/xterm'
 import { useSettingsStore, useAppStore, useToastStore } from '../stores'
+import { isClaudeLikeTerminal, isClaudeLikeTerminalId } from '../stores/app-store'
 import { pauseAndBuffer, resumeAndFlush } from '../utils/terminal-output-dispatcher'
 import { subscribeToSystemResume, unsubscribeFromSystemResume } from '../utils/terminal-lifecycle-dispatcher'
 import { subscribeToResizeEnd, unsubscribeFromResizeEnd } from '../utils/terminal-resize-end-dispatcher'
 import { triggerAltBufferRepaint, isResizeRepaintEnabled } from '../utils/trigger-alt-buffer-repaint'
+import { sendPtyResize } from '../utils/pty-resize-coordinator'
 
 // ── Per-terminal mutex ───────────────────────────────────────────────────────
 // Prevents concurrent snapshot replays (e.g. refresh + phase-4 auto-resync).
@@ -42,9 +44,7 @@ const REFRESH_DEBOUNCE = 100  // ms debounce for refreshTerminal()
 export function shouldUseWebGL(terminalId: string, _isActive?: boolean, _isHidden?: boolean): boolean {
   void _isActive; void _isHidden
   const { pendingSettings } = useSettingsStore.getState()
-  const isClaudeTerminal = useAppStore.getState().terminals.some(
-    terminal => terminal.id === terminalId && terminal.isClaudeMode
-  )
+  const isClaudeTerminal = isClaudeLikeTerminalId(terminalId)
 
   if (isClaudeTerminal && !pendingSettings.gpuRendererForClaudeTerminals) {
     return false
@@ -80,7 +80,7 @@ interface UseTerminalWebGLResult {
   /** Dispose + reload WebGL after theme change (cursor color requires full reload) */
   reloadWebGLForTheme: () => void
   /** Full display refresh via snapshot replay (debounced). showNotification defaults true. */
-  refreshTerminal: (showNotification?: boolean) => void
+  refreshTerminal: (showNotification?: boolean, preserveAltBuffer?: boolean) => void
 }
 
 interface SnapshotReplayParams {
@@ -199,13 +199,19 @@ export async function performSnapshotReplay(params: SnapshotReplayParams): Promi
 
     const fitOk = performFit(false)
 
-    // SIGWINCH — makes CLI (vim, tmux, etc.) repaint at current dimensions
-    try {
-      window.electron.terminal.resize(terminalId, t.cols, t.rows)
-    } catch { /* ignore — non-fatal */ }
+    // SIGWINCH — makes CLI (vim, tmux, etc.) repaint at current dimensions.
+    // Routed through the coordinator so this code path stays consistent with
+    // the regular onResize handler.
+    sendPtyResize({
+      terminalId,
+      xtermCols: t.cols,
+      rows: t.rows,
+      isAlt: t.buffer.active.type === 'alternate',
+      isClaudeMode: isClaudeLikeTerminalId(terminalId),
+    })
 
     // H4: drain buffered live chunks (arrival order preserved)
-    resumeAndFlush(terminalId)
+    resumeAndFlush(terminalId, { afterOffset: snap.byteOffset })
 
     if (!silent) {
       try {
@@ -344,8 +350,8 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
     const unsubscribe = useAppStore.subscribe((state, prevState) => {
       if (!terminalRef.current || disposedRef.current) return
 
-      const nextClaudeMode = state.terminals.find(t => t.id === terminalId)?.isClaudeMode ?? false
-      const prevClaudeMode = prevState.terminals.find(t => t.id === terminalId)?.isClaudeMode ?? false
+      const nextClaudeMode = isClaudeLikeTerminal(state.terminals.find(t => t.id === terminalId))
+      const prevClaudeMode = isClaudeLikeTerminal(prevState.terminals.find(t => t.id === terminalId))
 
       if (nextClaudeMode === prevClaudeMode) return
 
@@ -391,7 +397,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
    * Delegates to performSnapshotReplay() which holds the per-terminal mutex,
    * buffers live output during replay (H4), and handles disposal guard (M8).
    */
-  const refreshTerminal = useCallback((showNotification = true) => {
+  const refreshTerminal = useCallback((showNotification = true, preserveAltBuffer = false) => {
     if (disposedRef.current || !terminalRef.current) return
     if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current)
     refreshDebounceRef.current = setTimeout(() => {
@@ -407,6 +413,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
         reconcileWebGL,
         performFit,
         silent: !showNotification,
+        preserveAltBuffer,
       })
     }, REFRESH_DEBOUNCE)
   }, [clearTextureAtlas, disposedRef, isActiveRef, isHiddenRef, performFit, reconcileWebGL, terminalId, terminalRef, webglAddonRef])
@@ -452,13 +459,23 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
   // replay is already in flight (system-resume race) — that replay fires its own SIGWINCH.
   useEffect(() => {
     if (!isResizeRepaintEnabled()) return
-    subscribeToResizeEnd(terminalId, () => {
+    subscribeToResizeEnd(terminalId, (source) => {
       if (disposedRef.current || !terminalRef.current) return
       if (snapshotReplayMutex.has(terminalId)) return  // R3: skip during replay
+
+      if (
+        source === 'split' &&
+        terminalRef.current.buffer.active.type === 'normal' &&
+        isClaudeLikeTerminalId(terminalId)
+      ) {
+        refreshTerminal(false, true)
+        return
+      }
+
       triggerAltBufferRepaint(terminalId, terminalRef.current)
     })
     return () => unsubscribeFromResizeEnd(terminalId)
-  }, [terminalId, terminalRef, disposedRef])
+  }, [terminalId, terminalRef, disposedRef, refreshTerminal])
 
   return { reconcileWebGL, clearTextureAtlas, webglAddonRef, webglLoadingRef, reloadWebGLForTheme, refreshTerminal }
 }

--- a/src/renderer/hooks/use-terminal.ts
+++ b/src/renderer/hooks/use-terminal.ts
@@ -13,6 +13,8 @@ import { FitAddon } from '@xterm/addon-fit'
 import { TerminalScrollMachine } from '../utils/terminal-scroll-machine'
 import { resumeAndFlush as resumeTerminalOutput } from '../utils/terminal-output-dispatcher'
 import { publishResizeEnd } from '../utils/terminal-resize-end-dispatcher'
+import { clearPtyMaxCols, sendPtyResize } from '../utils/pty-resize-coordinator'
+import { isClaudeLikeTerminal, isClaudeLikeTerminalId, useAppStore } from '../stores/app-store'
 import { useTerminalWebGL } from './use-terminal-webgl'
 import { useTerminalFontTheme } from './use-terminal-font-theme'
 import { useTerminalKeyboard } from './use-terminal-keyboard'
@@ -57,7 +59,7 @@ export function useTerminal({
   const scrollDisposableRef = useRef<IDisposable | null>(null)
   const viewportListenersRef = useRef<ViewportEventListener[] | null>(null)
   const webglToggleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const refreshFnRef = useRef<((showNotification?: boolean) => void) | null>(null)
+  const refreshFnRef = useRef<((showNotification?: boolean, preserveAltBuffer?: boolean) => void) | null>(null)
 
   // ── Sub-hooks ──────────────────────────────────────────────────────────────
   const { registerTerminalDebugHandle, unregisterTerminalDebugHandle } =
@@ -93,11 +95,29 @@ export function useTerminal({
     })
 
   const { performFit, cancelScheduledFit, fit } = useTerminalFit({
+    terminalId,
     terminalRef, fitAddonRef, containerRef, disposedRef, scrollMachineRef, refreshVisibleRows,
-    // Part D: silent snapshot replay when cols change (reflow-safe scrollback setting gates this)
-    onColsChanged: () => refreshTerminal(false),
-    // Phase 01 alt-buffer repaint: publish resize-end for subscribers
-    onResizeEnd: () => publishResizeEnd(terminalId),
+    // When enabled, rebuild scrollback from raw PTY output after a settled cols
+    // change so old output is re-rendered at the visible width. Claude's
+    // inline normal-buffer UI appends full frames on resize/replay, so skip
+    // automatic rebuilds there.
+    onColsChanged: () => {
+      const t = terminalRef.current
+      if (t && isClaudeLikeTerminalId(terminalId) && t.buffer.active.type === 'normal') return
+      refreshTerminal(false, true)
+    },
+    onResizeEnd: (source, colsChange) => {
+      publishResizeEnd(terminalId, source)
+      const t = terminalRef.current
+      if (
+        t &&
+        t.buffer.active.type === 'normal' &&
+        colsChange.changed &&
+        isClaudeLikeTerminalId(terminalId)
+      ) {
+        refreshTerminal(false, true)
+      }
+    },
   })
   // Wire the ref so WebGL hook can call performFit
   performFitRef.current = performFit
@@ -108,7 +128,14 @@ export function useTerminal({
       if (disposedRef.current || !terminalRef.current || !fitAddonRef.current) return
       clearTextureAtlas()
       performFit()
-      window.electron.terminal.resize(terminalId, terminalRef.current.cols, terminalRef.current.rows)
+      const t = terminalRef.current
+      sendPtyResize({
+        terminalId,
+        xtermCols: t.cols,
+        rows: t.rows,
+        isAlt: t.buffer.active.type === 'alternate',
+        isClaudeMode: isClaudeLikeTerminalId(terminalId),
+      })
     },
     onWebGLReload: reloadWebGLForTheme,
   })
@@ -144,6 +171,23 @@ export function useTerminal({
     return () => { if (webglToggleTimerRef.current) clearTimeout(webglToggleTimerRef.current) }
   }, [isActive, isHidden, reconcileWebGL])
 
+  useEffect(() => {
+    const applyClaudeCursorReflowPolicy = () => {
+      const t = terminalRef.current
+      if (!t || disposedRef.current) return
+      t.options.reflowCursorLine = !isClaudeLikeTerminalId(terminalId)
+    }
+
+    applyClaudeCursorReflowPolicy()
+    const unsubscribe = useAppStore.subscribe((state, prevState) => {
+      const nextClaudeMode = isClaudeLikeTerminal(state.terminals.find(t => t.id === terminalId))
+      const prevClaudeMode = isClaudeLikeTerminal(prevState.terminals.find(t => t.id === terminalId))
+      if (nextClaudeMode === prevClaudeMode) return
+      applyClaudeCursorReflowPolicy()
+    })
+    return unsubscribe
+  }, [terminalId])
+
   // Keep refresh ref in sync so WebGL context-loss handler calls the latest refresh
   const refresh = refreshTerminal
   useEffect(() => { refreshFnRef.current = refresh }, [refresh])
@@ -158,6 +202,7 @@ export function useTerminal({
       // Drain any pause state set by initTerminal in case unmount races ahead
       // of snapshot-apply (prevents stuck pausedBuffer entry).
       resumeTerminalOutput(paneTerminalId)
+      clearPtyMaxCols(paneTerminalId)
       scrollMachine.reset()
       clearUserViewportInteraction()
       cancelScheduledFit()

--- a/src/renderer/hooks/use-terminal.ts
+++ b/src/renderer/hooks/use-terminal.ts
@@ -12,6 +12,7 @@ import { Terminal as XTerm, IDisposable } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { TerminalScrollMachine } from '../utils/terminal-scroll-machine'
 import { resumeAndFlush as resumeTerminalOutput } from '../utils/terminal-output-dispatcher'
+import { publishResizeEnd } from '../utils/terminal-resize-end-dispatcher'
 import { useTerminalWebGL } from './use-terminal-webgl'
 import { useTerminalFontTheme } from './use-terminal-font-theme'
 import { useTerminalKeyboard } from './use-terminal-keyboard'
@@ -95,6 +96,8 @@ export function useTerminal({
     terminalRef, fitAddonRef, containerRef, disposedRef, scrollMachineRef, refreshVisibleRows,
     // Part D: silent snapshot replay when cols change (reflow-safe scrollback setting gates this)
     onColsChanged: () => refreshTerminal(false),
+    // Phase 01 alt-buffer repaint: publish resize-end for subscribers
+    onResizeEnd: () => publishResizeEnd(terminalId),
   })
   // Wire the ref so WebGL hook can call performFit
   performFitRef.current = performFit

--- a/src/renderer/stores/app-store.spec.ts
+++ b/src/renderer/stores/app-store.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { TERMINAL_OUTPUT_BUFFER_MAX, TERMINAL_OUTPUT_BUFFER_TRIM_TO } from '@shared/constants'
 import type { Terminal } from '@shared/types'
-import { useAppStore } from './app-store'
+import { isClaudeLikeTerminalId, useAppStore } from './app-store'
 import { resetBufferedTerminalOutputForTests } from './terminal-output-buffer'
 
 const initialState = useAppStore.getState()
@@ -120,5 +120,38 @@ describe('useAppStore terminal output buffering', () => {
     state.updateTerminalClaudeMode?.('term-1', true)
 
     expect(useAppStore.getState().terminals[0]?.isClaudeMode).toBe(true)
+    expect(useAppStore.getState().terminals[0]?.agentType).toBe('claude')
+  })
+
+  it('treats a detected claude agent as Claude mode for renderer guards', () => {
+    useAppStore.getState().addTerminal(makeTerminal())
+
+    useAppStore.getState().updateTerminalAgentType('term-1', 'claude')
+
+    expect(useAppStore.getState().terminals[0]?.isClaudeMode).toBe(true)
+    expect(isClaudeLikeTerminalId('term-1')).toBe(true)
+  })
+
+  it('clears Claude-like metadata when Claude mode is explicitly disabled', () => {
+    useAppStore.getState().addTerminal(makeTerminal())
+
+    useAppStore.getState().updateTerminalClaudeSessionId('term-1', 'session-123')
+    useAppStore.getState().updateTerminalClaudeMode('term-1', false)
+
+    const terminal = useAppStore.getState().terminals[0]
+    expect(terminal?.isClaudeMode).toBe(false)
+    expect(terminal?.agentType).toBeUndefined()
+    expect(terminal?.claudeSessionId).toBeUndefined()
+    expect(isClaudeLikeTerminalId('term-1')).toBe(false)
+  })
+
+  it('treats a bound Claude session id as Claude mode for restored terminals', () => {
+    useAppStore.getState().addTerminal(makeTerminal())
+
+    useAppStore.getState().updateTerminalClaudeSessionId('term-1', 'session-123')
+
+    expect(useAppStore.getState().terminals[0]?.isClaudeMode).toBe(true)
+    expect(useAppStore.getState().terminals[0]?.agentType).toBe('claude')
+    expect(isClaudeLikeTerminalId('term-1')).toBe(true)
   })
 })

--- a/src/renderer/stores/app-store.ts
+++ b/src/renderer/stores/app-store.ts
@@ -13,6 +13,16 @@ export type ActiveView = 'terminals' | 'github'
 
 const DEFAULT_PROJECT_KEY = '__default_project__'
 
+export function isClaudeLikeTerminal(terminal: Pick<Terminal, 'isClaudeMode' | 'agentType' | 'claudeSessionId'> | undefined): boolean {
+  return !!terminal && (terminal.isClaudeMode || terminal.agentType === 'claude' || !!terminal.claudeSessionId)
+}
+
+export function isClaudeLikeTerminalId(terminalId: string): boolean {
+  return useAppStore.getState().terminals.some(
+    terminal => terminal.id === terminalId && isClaudeLikeTerminal(terminal)
+  )
+}
+
 function getTerminalProjectKey(projectId?: string): string {
   return projectId ?? DEFAULT_PROJECT_KEY
 }
@@ -164,21 +174,39 @@ export const useAppStore = create<AppState>((set, get) => ({
   updateTerminalClaudeMode: (id, isClaudeMode) =>
     set((state) => ({
       terminals: state.terminals.map((t) =>
-        t.id === id ? { ...t, isClaudeMode } : t
+        t.id === id
+          ? {
+              ...t,
+              isClaudeMode,
+              agentType: isClaudeMode
+                ? (t.agentType ?? 'claude')
+                : t.agentType === 'claude' ? undefined : t.agentType,
+              claudeSessionId: isClaudeMode ? t.claudeSessionId : undefined,
+            }
+          : t
       )
     })),
 
   updateTerminalAgentType: (id, agentType) =>
     set((state) => ({
       terminals: state.terminals.map((t) =>
-        t.id === id ? { ...t, agentType } : t
+        t.id === id
+          ? { ...t, agentType, isClaudeMode: agentType === 'claude' ? true : t.isClaudeMode }
+          : t
       )
     })),
 
   updateTerminalClaudeSessionId: (id, claudeSessionId) =>
     set((state) => ({
       terminals: state.terminals.map((t) =>
-        t.id === id ? { ...t, claudeSessionId } : t
+        t.id === id
+          ? {
+              ...t,
+              claudeSessionId,
+              isClaudeMode: claudeSessionId ? true : t.isClaudeMode,
+              agentType: claudeSessionId ? (t.agentType ?? 'claude') : t.agentType,
+            }
+          : t
       )
     })),
 

--- a/src/renderer/utils/__tests__/pty-resize-coordinator.spec.ts
+++ b/src/renderer/utils/__tests__/pty-resize-coordinator.spec.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * Tests for pty-resize-coordinator — the single chokepoint for SIGWINCH traffic.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  sendPtyResize,
+  clearPtyMaxCols,
+  _getPtyMaxColsForTests,
+  _resetForTests,
+} from '../pty-resize-coordinator'
+
+function stubElectronTerminal() {
+  const resize = vi.fn()
+  const resizeHeadless = vi.fn()
+  vi.stubGlobal('electron', { terminal: { resize, resizeHeadless } })
+  return { resize, resizeHeadless }
+}
+
+describe('pty-resize-coordinator', () => {
+  beforeEach(() => {
+    _resetForTests()
+    vi.unstubAllGlobals()
+  })
+
+  it('normal-buffer resize updates only the headless mirror', () => {
+    const ipc = stubElectronTerminal()
+    const r = sendPtyResize({ terminalId: 't1', xtermCols: 80, rows: 24, isAlt: false })
+    expect(r.sentCols).toBe(80)
+    expect(r.decoupled).toBe(false)
+    expect(r.skipped).toBe(true)
+    expect(ipc.resize).not.toHaveBeenCalled()
+    expect(ipc.resizeHeadless).toHaveBeenCalledWith('t1', 80, 24)
+  })
+
+  it('normal-buffer shrink does not send SIGWINCH to the PTY', () => {
+    const ipc = stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 100, rows: 30, isAlt: false })
+    const r = sendPtyResize({ terminalId: 't1', xtermCols: 30, rows: 30, isAlt: false })
+    expect(r.sentCols).toBe(30)
+    expect(r.decoupled).toBe(false)
+    expect(r.skipped).toBe(true)
+    expect(ipc.resize).not.toHaveBeenCalled()
+    expect(ipc.resizeHeadless).toHaveBeenLastCalledWith('t1', 30, 30)
+  })
+
+  it('normal-buffer widen does not send SIGWINCH to the PTY', () => {
+    const ipc = stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 80, rows: 24, isAlt: false })
+    const r = sendPtyResize({ terminalId: 't1', xtermCols: 120, rows: 24, isAlt: false })
+    expect(r.sentCols).toBe(120)
+    expect(r.decoupled).toBe(false)
+    expect(r.skipped).toBe(true)
+    expect(ipc.resize).not.toHaveBeenCalled()
+    expect(ipc.resizeHeadless).toHaveBeenLastCalledWith('t1', 120, 24)
+  })
+
+  it('skips Claude normal-buffer SIGWINCH to avoid inline redraw duplication', () => {
+    const ipc = stubElectronTerminal()
+    const r = sendPtyResize({
+      terminalId: 't1',
+      xtermCols: 40,
+      rows: 20,
+      isAlt: false,
+      isClaudeMode: true,
+    })
+
+    expect(r.sentCols).toBe(40)
+    expect(r.decoupled).toBe(false)
+    expect(r.skipped).toBe(true)
+    expect(ipc.resize).not.toHaveBeenCalled()
+    expect(ipc.resizeHeadless).toHaveBeenCalledWith('t1', 40, 20)
+  })
+
+  it('alt-screen also syncs cols 1:1', () => {
+    const ipc = stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 100, rows: 30, isAlt: false })
+    const r = sendPtyResize({ terminalId: 't1', xtermCols: 40, rows: 30, isAlt: true, isClaudeMode: true })
+    expect(r.sentCols).toBe(40)
+    expect(r.decoupled).toBe(false)
+    expect(r.skipped).toBe(false)
+    expect(ipc.resize).toHaveBeenLastCalledWith('t1', 40, 30)
+  })
+
+  it('does not retain per-terminal high-water cols', () => {
+    stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 80, rows: 24, isAlt: false })
+    expect(_getPtyMaxColsForTests('t1')).toBeUndefined()
+  })
+
+  it('clearPtyMaxCols is safe after exact resizes', () => {
+    stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 100, rows: 30, isAlt: false })
+    clearPtyMaxCols('t1')
+    expect(_getPtyMaxColsForTests('t1')).toBeUndefined()
+  })
+
+  it('exit alt-screen at narrow width: next normal-buffer resize remains exact', () => {
+    const ipc = stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 100, rows: 30, isAlt: false })
+    sendPtyResize({ terminalId: 't1', xtermCols: 40, rows: 30, isAlt: true })
+    expect(ipc.resize).toHaveBeenLastCalledWith('t1', 40, 30)
+    sendPtyResize({ terminalId: 't1', xtermCols: 40, rows: 30, isAlt: false })
+    expect(ipc.resize).toHaveBeenCalledTimes(1)
+    expect(ipc.resizeHeadless).toHaveBeenLastCalledWith('t1', 40, 30)
+  })
+})

--- a/src/renderer/utils/__tests__/terminal-resize-end-dispatcher.spec.ts
+++ b/src/renderer/utils/__tests__/terminal-resize-end-dispatcher.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isAutoResizeRefreshSuppressed,
+  resetResizeEndDispatcherForTests,
+  suppressAutoResizeRefreshForTerminals,
+} from '../terminal-resize-end-dispatcher'
+
+describe('terminal-resize-end-dispatcher auto refresh suppression', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-16T00:00:00.000Z'))
+    resetResizeEndDispatcherForTests()
+  })
+
+  afterEach(() => {
+    resetResizeEndDispatcherForTests()
+    vi.useRealTimers()
+  })
+
+  it('suppresses auto refresh for each remaining terminal during layout collapse', () => {
+    suppressAutoResizeRefreshForTerminals(['term-a', 'term-b'], 1200)
+
+    expect(isAutoResizeRefreshSuppressed('term-a')).toBe(true)
+    expect(isAutoResizeRefreshSuppressed('term-b')).toBe(true)
+    expect(isAutoResizeRefreshSuppressed('term-closed')).toBe(false)
+  })
+})

--- a/src/renderer/utils/__tests__/trigger-alt-buffer-repaint.spec.ts
+++ b/src/renderer/utils/__tests__/trigger-alt-buffer-repaint.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { triggerAltBufferRepaint } from '../trigger-alt-buffer-repaint'
+import { sendPtyResize, _resetForTests } from '../pty-resize-coordinator'
+
+function stubElectronTerminal() {
+  const resize = vi.fn()
+  vi.stubGlobal('electron', { terminal: { resize } })
+  return resize
+}
+
+describe('triggerAltBufferRepaint', () => {
+  beforeEach(() => {
+    _resetForTests()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not send a duplicate normal-buffer resize at resize end', () => {
+    const ipc = stubElectronTerminal()
+    sendPtyResize({ terminalId: 't1', xtermCols: 120, rows: 30, isAlt: false })
+    ipc.mockClear()
+
+    triggerAltBufferRepaint('t1', {
+      cols: 40,
+      rows: 30,
+      buffer: { active: { type: 'normal' } },
+      write: vi.fn(),
+    } as never)
+
+    expect(ipc).not.toHaveBeenCalledWith('t1', 40, 30)
+  })
+
+  it('does not clear or repaint normal-buffer panes at resize end', () => {
+    const ipc = stubElectronTerminal()
+    const write = vi.fn()
+
+    triggerAltBufferRepaint('t1', {
+      cols: 40,
+      rows: 30,
+      buffer: { active: { type: 'normal' } },
+      write,
+    } as never)
+
+    expect(write).not.toHaveBeenCalled()
+    expect(ipc).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/utils/insert-file-paths.ts
+++ b/src/renderer/utils/insert-file-paths.ts
@@ -1,4 +1,5 @@
-import { useAppStore, useImageStore } from '../stores'
+import { useImageStore } from '../stores'
+import { isClaudeLikeTerminalId } from '../stores/app-store'
 import { classifyMediaFile } from './media-classifier'
 import { formatPathForTerminal, joinPathsForClaudeTerminal } from './terminal-path-utils'
 
@@ -23,7 +24,7 @@ import { formatPathForTerminal, joinPathsForClaudeTerminal } from './terminal-pa
  *      write still avoids the multi-paste drop-all-but-first bug the
  *      d888103 commit originally tried to fix. */
 export function insertFilePathsIntoTerminal(terminalId: string, paths: string[]): void {
-  const isClaudeMode = useAppStore.getState().terminals.find((t) => t.id === terminalId)?.isClaudeMode ?? false
+  const isClaudeMode = isClaudeLikeTerminalId(terminalId)
 
   if (isClaudeMode) {
     for (const filePath of paths) {

--- a/src/renderer/utils/pane-drag-state.ts
+++ b/src/renderer/utils/pane-drag-state.ts
@@ -2,12 +2,8 @@
  * Global signal for "a pane divider is currently being dragged".
  *
  * Rapid drag fires ResizeObserver at display refresh rate on every affected
- * pane. Each fire triggers xterm fit() → terminal.resize(cols, rows) → xterm
- * internal reflow. When the user drags the divider to a very narrow width
- * then back, xterm's reflow can leave wrapped rows orphaned in scrollback
- * (character-per-line stretched blocks, duplicated banners). Suspend fit()
- * for the duration of the drag and commit a single fit at rest position
- * when the drag ends.
+ * pane. Hooks use this signal to keep local xterm fit responsive while
+ * suppressing expensive or stateful resize side effects until drag end.
  */
 type Listener = () => void
 

--- a/src/renderer/utils/pty-resize-coordinator.ts
+++ b/src/renderer/utils/pty-resize-coordinator.ts
@@ -1,0 +1,70 @@
+/**
+ * pty-resize-coordinator — single chokepoint for SIGWINCH-to-PTY traffic.
+ *
+ * Keep resize traffic to the PTY predictable.
+ *
+ * Normal-buffer shells and inline agent UIs redraw inconsistently on SIGWINCH:
+ * fish can duplicate the prompt, and Claude appends freshly redrawn frames
+ * while old frames remain in scrollback. Keep PTY size stable in the normal
+ * buffer; only sync the headless mirror so snapshot refreshes match the visual
+ * pane. Full-screen alt-buffer apps still receive exact PTY dimensions.
+ */
+
+export interface SendPtyResizeArgs {
+  terminalId: string
+  /** xterm.cols at the time of the resize event. */
+  xtermCols: number
+  /** Current rows — always forwarded as-is. */
+  rows: number
+  /** Whether the terminal is currently in alt-screen mode. */
+  isAlt: boolean
+  /** Whether this terminal is currently running Claude Code. Kept for logging callers. */
+  isClaudeMode?: boolean
+}
+
+export interface SendPtyResizeResult {
+  /** The cols actually sent to the PTY. */
+  sentCols: number
+  /** True if PTY cols diverged from xterm cols. Kept for logging compatibility. */
+  decoupled: boolean
+  /** True when SIGWINCH is intentionally suppressed. Kept for caller logging. */
+  skipped: boolean
+}
+
+export function sendPtyResize(args: SendPtyResizeArgs): SendPtyResizeResult {
+  const { terminalId, xtermCols, rows, isAlt } = args
+  const sentCols = xtermCols
+
+  if (!isAlt) {
+    try {
+      window.electron.terminal.resizeHeadless?.(terminalId, sentCols, rows)
+    } catch {
+      // Non-fatal: older preload/main during hot reload, or teardown race.
+    }
+    return { sentCols, decoupled: false, skipped: true }
+  }
+
+  try {
+    window.electron.terminal.resize(terminalId, sentCols, rows)
+  } catch {
+    // Non-fatal: main may have torn down during pane close.
+  }
+
+  return { sentCols, decoupled: false, skipped: false }
+}
+
+/** Clear high-water resize state on terminal teardown. */
+export function clearPtyMaxCols(terminalId: string): void {
+  void terminalId
+}
+
+/** Test helper — exposed only for unit tests. */
+export function _getPtyMaxColsForTests(terminalId: string): number | undefined {
+  void terminalId
+  return undefined
+}
+
+/** Test helper — reset internal state. */
+export function _resetForTests(): void {
+  // No retained state.
+}

--- a/src/renderer/utils/terminal-output-dispatcher.spec.ts
+++ b/src/renderer/utils/terminal-output-dispatcher.spec.ts
@@ -128,6 +128,40 @@ describe('terminal-output-dispatcher', () => {
       expect(handler.mock.calls[2][0]).toBe('third')
     })
 
+    it('drops buffered chunks already covered by a snapshot offset', () => {
+      const handler = vi.fn()
+      registerTerminalOutputHandler('term-1', handler)
+      pauseAndBuffer('term-1')
+
+      attachTerminalOutputDispatcher((callback) => {
+        callback({ terminalId: 'term-1', data: 'first', startOffset: 0, endOffset: 5 })
+        callback({ terminalId: 'term-1', data: 'second', startOffset: 5, endOffset: 11 })
+        return vi.fn()
+      })
+
+      resumeAndFlush('term-1', { afterOffset: 11 })
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('flushes only the suffix of a chunk that extends beyond the snapshot offset', () => {
+      const handler = vi.fn()
+      registerTerminalOutputHandler('term-1', handler)
+      pauseAndBuffer('term-1')
+
+      attachTerminalOutputDispatcher((callback) => {
+        callback({ terminalId: 'term-1', data: 'abcdef', startOffset: 10, endOffset: 16 })
+        callback({ terminalId: 'term-1', data: 'ghi', startOffset: 16, endOffset: 19 })
+        return vi.fn()
+      })
+
+      resumeAndFlush('term-1', { afterOffset: 13 })
+
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(handler.mock.calls[0][0]).toBe('def')
+      expect(handler.mock.calls[1][0]).toBe('ghi')
+    })
+
     it('resumes normal dispatch after resumeAndFlush', () => {
       const handler = vi.fn()
       registerTerminalOutputHandler('term-1', handler)

--- a/src/renderer/utils/terminal-output-dispatcher.ts
+++ b/src/renderer/utils/terminal-output-dispatcher.ts
@@ -1,6 +1,8 @@
 type TerminalOutputPayload = {
   terminalId: string
   data: string
+  startOffset?: number
+  endOffset?: number
 }
 
 type TerminalOutputHandler = (data: string) => void
@@ -9,7 +11,7 @@ const terminalOutputHandlers = new Map<string, TerminalOutputHandler>()
 
 // Per-terminal buffer: when paused, incoming chunks are queued here instead of
 // being forwarded to the handler.  On resume the queue is drained in arrival order.
-const pausedBuffers = new Map<string, string[]>()
+const pausedBuffers = new Map<string, TerminalOutputPayload[]>()
 
 /**
  * Pause output dispatching for a terminal.
@@ -26,7 +28,29 @@ export function pauseAndBuffer(id: string): void {
  * Flushes buffered chunks to the registered handler in arrival order,
  * then resumes normal (unbuffered) dispatch.
  */
-export function resumeAndFlush(id: string): void {
+interface ResumeAndFlushOptions {
+  /**
+   * Drop buffered bytes that are already represented by a backend snapshot.
+   * Offsets use the main-process terminal output stream's string-length counter.
+   */
+  afterOffset?: number
+}
+
+function sliceAfterOffset(payload: TerminalOutputPayload, afterOffset: number | undefined): string {
+  if (
+    afterOffset === undefined ||
+    payload.startOffset === undefined ||
+    payload.endOffset === undefined
+  ) {
+    return payload.data
+  }
+
+  if (payload.endOffset <= afterOffset) return ''
+  if (payload.startOffset >= afterOffset) return payload.data
+  return payload.data.slice(afterOffset - payload.startOffset)
+}
+
+export function resumeAndFlush(id: string, options: ResumeAndFlushOptions = {}): void {
   const buffer = pausedBuffers.get(id)
   if (!buffer) return
 
@@ -35,8 +59,9 @@ export function resumeAndFlush(id: string): void {
 
   const handler = terminalOutputHandlers.get(id)
   if (handler) {
-    for (const chunk of buffer) {
-      handler(chunk)
+    for (const payload of buffer) {
+      const chunk = sliceAfterOffset(payload, options.afterOffset)
+      if (chunk) handler(chunk)
     }
   }
 }
@@ -53,13 +78,13 @@ export function registerTerminalOutputHandler(id: string, handler: TerminalOutpu
 export function attachTerminalOutputDispatcher(
   subscribe: (callback: (payload: TerminalOutputPayload) => void) => () => void
 ): () => void {
-  return subscribe(({ terminalId, data }) => {
-    const buffer = pausedBuffers.get(terminalId)
+  return subscribe((payload) => {
+    const buffer = pausedBuffers.get(payload.terminalId)
     if (buffer) {
-      buffer.push(data)
+      buffer.push(payload)
       return
     }
-    terminalOutputHandlers.get(terminalId)?.(data)
+    terminalOutputHandlers.get(payload.terminalId)?.(payload.data)
   })
 }
 

--- a/src/renderer/utils/terminal-resize-debug.ts
+++ b/src/renderer/utils/terminal-resize-debug.ts
@@ -1,0 +1,43 @@
+/**
+ * terminal-resize-debug — gated console logging for resize flow diagnosis.
+ *
+ * Enable via DevTools console:
+ *   localStorage.terminalResizeDebug = '1'
+ *   // (reload not required — read on every log call)
+ *
+ * Disable:
+ *   delete localStorage.terminalResizeDebug
+ *
+ * Or set at runtime:
+ *   window.__TERMINAL_RESIZE_DEBUG__ = true
+ *
+ * Log categories (filter in DevTools console):
+ *   [RESIZE observer]   container size change from ResizeObserver
+ *   [RESIZE fit]        performFit lifecycle (propose, skip, done, cols-changed)
+ *   [RESIZE ipc]        IPC SIGWINCH sent to main/PTY
+ *   [RESIZE replay]     reflow-safe snapshot replay fire
+ *   [RESIZE end]        trailing-edge resize-end events
+ *
+ * Each log includes terminalId + cols/rows/width/height to correlate paths.
+ */
+
+type DebugWindow = typeof window & {
+  __TERMINAL_RESIZE_DEBUG__?: boolean
+}
+
+export function isResizeDebugEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+  const w = window as DebugWindow
+  if (w.__TERMINAL_RESIZE_DEBUG__ === true) return true
+  try {
+    return window.localStorage?.getItem('terminalResizeDebug') === '1'
+  } catch {
+    return false
+  }
+}
+
+export function logResize(category: string, terminalId: string, data: Record<string, unknown>): void {
+  if (!isResizeDebugEnabled()) return
+  const ts = new Date().toISOString().slice(11, 23) // HH:MM:SS.mmm
+  console.log(`[RESIZE ${category}] ${ts} ${terminalId}`, data)
+}

--- a/src/renderer/utils/terminal-resize-end-dispatcher.ts
+++ b/src/renderer/utils/terminal-resize-end-dispatcher.ts
@@ -5,14 +5,20 @@
  * resize gesture" events (drag-end, split-end, window-resize trailing edge).
  *
  * Each terminal subscribes once; publish sites fire by terminalId. Used by
- * use-terminal-webgl.ts to trigger alt-buffer repaint after layout settles.
+ * use-terminal-webgl.ts to trigger alt-buffer repaint after layout settles,
+ * and to run heavier snapshot repair for resize sources that can corrupt
+ * normal-buffer scrollback.
  *
  * No IPC involved — pure in-process pub/sub.
  */
 
-type ResizeEndCallback = () => void
+export type ResizeEndSource = 'pane-drag' | 'window' | 'split' | 'external'
+
+type ResizeEndCallback = (source: ResizeEndSource) => void
 
 const handlers = new Map<string, ResizeEndCallback>()
+const autoRefreshSuppressedUntil = new Map<string, number>()
+const SPLIT_AUTO_REFRESH_SUPPRESSION_MS = 1200
 
 export function subscribeToResizeEnd(terminalId: string, callback: ResizeEndCallback): void {
   handlers.set(terminalId, callback)
@@ -22,17 +28,42 @@ export function unsubscribeFromResizeEnd(terminalId: string): void {
   handlers.delete(terminalId)
 }
 
-export function publishResizeEnd(terminalId: string): void {
+export function publishResizeEnd(terminalId: string, source: ResizeEndSource = 'external'): void {
   const handler = handlers.get(terminalId)
   if (!handler) return
   try {
-    handler()
+    handler(source)
   } catch (err) {
     console.error('[resize-end-dispatcher] handler threw:', err)
   }
 }
 
+export function suppressAutoResizeRefresh(
+  terminalId: string,
+  durationMs = SPLIT_AUTO_REFRESH_SUPPRESSION_MS,
+): void {
+  autoRefreshSuppressedUntil.set(terminalId, Date.now() + durationMs)
+}
+
+export function suppressAutoResizeRefreshForTerminals(
+  terminalIds: string[],
+  durationMs = SPLIT_AUTO_REFRESH_SUPPRESSION_MS,
+): void {
+  for (const terminalId of terminalIds) {
+    suppressAutoResizeRefresh(terminalId, durationMs)
+  }
+}
+
+export function isAutoResizeRefreshSuppressed(terminalId: string): boolean {
+  const suppressedUntil = autoRefreshSuppressedUntil.get(terminalId)
+  if (suppressedUntil === undefined) return false
+  if (Date.now() <= suppressedUntil) return true
+  autoRefreshSuppressedUntil.delete(terminalId)
+  return false
+}
+
 /** Test helper — clears subscriptions. Never call from production code. */
 export function resetResizeEndDispatcherForTests(): void {
   handlers.clear()
+  autoRefreshSuppressedUntil.clear()
 }

--- a/src/renderer/utils/terminal-resize-end-dispatcher.ts
+++ b/src/renderer/utils/terminal-resize-end-dispatcher.ts
@@ -1,0 +1,38 @@
+/**
+ * Terminal resize-end event dispatcher — renderer-internal pub/sub.
+ *
+ * Mirrors terminal-lifecycle-dispatcher.ts pattern but for "user finished a
+ * resize gesture" events (drag-end, split-end, window-resize trailing edge).
+ *
+ * Each terminal subscribes once; publish sites fire by terminalId. Used by
+ * use-terminal-webgl.ts to trigger alt-buffer repaint after layout settles.
+ *
+ * No IPC involved — pure in-process pub/sub.
+ */
+
+type ResizeEndCallback = () => void
+
+const handlers = new Map<string, ResizeEndCallback>()
+
+export function subscribeToResizeEnd(terminalId: string, callback: ResizeEndCallback): void {
+  handlers.set(terminalId, callback)
+}
+
+export function unsubscribeFromResizeEnd(terminalId: string): void {
+  handlers.delete(terminalId)
+}
+
+export function publishResizeEnd(terminalId: string): void {
+  const handler = handlers.get(terminalId)
+  if (!handler) return
+  try {
+    handler()
+  } catch (err) {
+    console.error('[resize-end-dispatcher] handler threw:', err)
+  }
+}
+
+/** Test helper — clears subscriptions. Never call from production code. */
+export function resetResizeEndDispatcherForTests(): void {
+  handlers.clear()
+}

--- a/src/renderer/utils/trigger-alt-buffer-repaint.ts
+++ b/src/renderer/utils/trigger-alt-buffer-repaint.ts
@@ -8,9 +8,10 @@
  *
  *   1. If alt-buffer active → write `\x1b[2J\x1b[H` (clear screen + home).
  *      The app's next paint becomes a full repaint at the new dimensions.
- *   2. Always: call IPC resize directly (bypasses lastSent dedup at
- *      use-terminal-init.ts:439) so a fresh SIGWINCH reaches the PTY even
- *      when (cols, rows) didn't change at renderer level.
+ *   2. If alt-buffer active → call IPC resize directly so a fresh SIGWINCH
+ *      reaches the PTY even when (cols, rows) didn't change at renderer level.
+ *      Normal-buffer panes skip this because the regular onResize path already
+ *      keeps PTY dimensions synced to the visible grid.
  *
  * Caller (use-terminal-webgl.ts subscriber) is responsible for:
  *   - feature flag gate (VITE_MULTICLAUDE_RESIZE_REPAINT)
@@ -19,19 +20,28 @@
  */
 
 import type { Terminal as XTerm } from '@xterm/xterm'
+import { logResize } from './terminal-resize-debug'
+import { sendPtyResize } from './pty-resize-coordinator'
 
-export function triggerAltBufferRepaint(terminalId: string, term: XTerm): void {
-  // Clear stale alt-buffer grid so app's next render is a full repaint
-  if (term.buffer.active.type === 'alternate') {
+export function triggerAltBufferRepaint(
+  terminalId: string,
+  term: XTerm
+): void {
+  const bufferType = term.buffer.active.type
+  if (bufferType === 'alternate') {
+    // Alt-screen TUIs (vim, htop, less) clear-and-redraw on SIGWINCH. We
+    // pre-clear the grid so the next full-frame paint isn't layered on top of
+    // a stale frame at the old dimensions.
     term.write('\x1b[2J\x1b[H')
+    logResize('ipc', terminalId, { phase: 'send-sigwinch-bypass', cols: term.cols, rows: term.rows })
+    sendPtyResize({ terminalId, xtermCols: term.cols, rows: term.rows, isAlt: true })
+    return
   }
 
-  // Force SIGWINCH by calling IPC directly (bypasses renderer debounce/dedup)
-  try {
-    window.electron.terminal.resize(terminalId, term.cols, term.rows)
-  } catch {
-    // ignore — non-fatal (main may have torn down during pane close)
-  }
+  // Normal buffer: the debounced onResize path has already sent the visible
+  // dimensions. Avoid a duplicate SIGWINCH at resize-end; fish and inline TUIs
+  // can redraw prompts noisily when they receive redundant resize events.
+  void terminalId
 }
 
 /** Feature flag — default ON. Set VITE_MULTICLAUDE_RESIZE_REPAINT=0 to disable. */

--- a/src/renderer/utils/trigger-alt-buffer-repaint.ts
+++ b/src/renderer/utils/trigger-alt-buffer-repaint.ts
@@ -1,0 +1,40 @@
+/**
+ * triggerAltBufferRepaint — force alt-screen TUI to fully redraw after a resize.
+ *
+ * Problem: when user finishes a drag/split/window-resize, SIGWINCH may have
+ * already fired via the natural xterm.onResize → debounce → IPC chain. But
+ * alt-screen apps (Claude TUI, vim, tmux) often repaint only their cursor
+ * area on SIGWINCH and leave stale grid content. This helper:
+ *
+ *   1. If alt-buffer active → write `\x1b[2J\x1b[H` (clear screen + home).
+ *      The app's next paint becomes a full repaint at the new dimensions.
+ *   2. Always: call IPC resize directly (bypasses lastSent dedup at
+ *      use-terminal-init.ts:439) so a fresh SIGWINCH reaches the PTY even
+ *      when (cols, rows) didn't change at renderer level.
+ *
+ * Caller (use-terminal-webgl.ts subscriber) is responsible for:
+ *   - feature flag gate (VITE_MULTICLAUDE_RESIZE_REPAINT)
+ *   - snapshot-replay mutex check (avoid racing system-resume replay)
+ *   - disposal guard
+ */
+
+import type { Terminal as XTerm } from '@xterm/xterm'
+
+export function triggerAltBufferRepaint(terminalId: string, term: XTerm): void {
+  // Clear stale alt-buffer grid so app's next render is a full repaint
+  if (term.buffer.active.type === 'alternate') {
+    term.write('\x1b[2J\x1b[H')
+  }
+
+  // Force SIGWINCH by calling IPC directly (bypasses renderer debounce/dedup)
+  try {
+    window.electron.terminal.resize(terminalId, term.cols, term.rows)
+  } catch {
+    // ignore — non-fatal (main may have torn down during pane close)
+  }
+}
+
+/** Feature flag — default ON. Set VITE_MULTICLAUDE_RESIZE_REPAINT=0 to disable. */
+export function isResizeRepaintEnabled(): boolean {
+  return import.meta.env.VITE_MULTICLAUDE_RESIZE_REPAINT !== '0'
+}

--- a/src/shared/constants/ipc-channels.ts
+++ b/src/shared/constants/ipc-channels.ts
@@ -6,6 +6,7 @@ export const IPC_CHANNELS = {
   TERMINAL_INPUT: 'terminal:input',
   TERMINAL_OUTPUT: 'terminal:output',
   TERMINAL_RESIZE: 'terminal:resize',
+  TERMINAL_RESIZE_HEADLESS: 'terminal:resize-headless',
   TERMINAL_LIST: 'terminal:list',
   TERMINAL_INVOKE_CLAUDE: 'terminal:invoke-claude',
   TERMINAL_TITLE_CHANGE: 'terminal:title-change',


### PR DESCRIPTION
## Summary
- preserve terminal resize history so snapshot replay uses the width active when output was emitted
- coordinate pane/window resize handling to avoid corrupting normal-buffer scrollback while still resizing alt-buffer TUIs
- add focused coverage for resize fit policy, resize coordination, snapshot refresh, and alt-buffer repaint paths

## Related issues
- None found from GitHub issue search for terminal resize/reflow terms.

## Test plan
- [x] npm test -- src/main/terminal/__tests__/terminal-manager.spec.ts src/main/terminal/__tests__/terminal-snapshot.spec.ts src/renderer/hooks/__tests__/use-terminal-fit.spec.ts src/renderer/hooks/__tests__/use-terminal-init-resize.spec.ts src/renderer/hooks/__tests__/use-terminal-resize-policy.spec.ts src/renderer/utils/__tests__/pty-resize-coordinator.spec.ts src/renderer/utils/__tests__/terminal-resize-end-dispatcher.spec.ts src/renderer/utils/__tests__/trigger-alt-buffer-repaint.spec.ts
- [x] npm run typecheck