### PR TITLE
feat(terminal): add automatic renderer policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Built for developers who want the speed of Claude Code in a local terminal, but 
 - **Provider-Neutral Agent Insights**: The managed-agent boundary supports Claude and Codex projections, while the UI exposes only available usage, tool, compaction, and reasoning capabilities with explicit source, precision, confidence, and unavailable states.
 - **Git + GitHub Inside the App**: Visual git status, staging, branches, stash, history, GitHub auth via `gh`, remote repo creation, plus issue and pull request views.
 - **Notification Pipeline for Agent Runs**: Detect complete, failed, and review-needed output patterns, then route alerts through native OS notifications, Telegram bots, or Discord webhooks; multi-agent detection included.
-- **Desktop-First Terminal UX**: Native PTY terminals with configurable rendering modes, drag-and-drop file paths with thumbnail preview strip (80×60 tiles), clipboard image path insertion, WSL-aware shell handling, cross-platform shell selection, and global shortcuts.
+- **Desktop-First Terminal UX**: Native PTY terminals with an automatic, compatibility-first renderer policy, drag-and-drop file paths with thumbnail preview strip (80×60 tiles), clipboard image path insertion, WSL-aware shell handling, cross-platform shell selection, and global shortcuts.
 - **Polished Local Distribution**: Cross-platform installers, in-app auto-updates, changelog display, 7 UI themes + 5 terminal ANSI palettes, and light/dark/system appearance without requiring a backend service.
 
 ## Ecosystem
@@ -170,19 +170,20 @@ Configure in Settings > Notifications:
 
 Detected events: Task Complete, Task Failed, Review Needed
 
-## Terminal Rendering Modes
+## Terminal Renderer Policy
 
-Configure in Settings > Terminals:
+Configure `Automatic`, `Prefer GPU`, or `Compatibility` in Settings >
+Diagnostics. Automatic is the default: regular shells attempt WebGL, while
+Claude and Codex use safer DOM rendering. Prefer GPU attempts WebGL for every
+terminal; Compatibility disables WebGL. Any WebGL failure falls back per pane,
+and recoverable faults expose a terminal-local Retry GPU action.
 
-| Mode | Description |
-|------|-------------|
-| Performance | No WebGL, best for many terminals |
-| Balanced | WebGL on active terminal only (default) |
-| Quality | WebGL always enabled, best visuals |
-
-Settings > Diagnostics includes a privacy-safe terminal stream report with the
-detected provider, selected engine, backend availability, last sequence and
-committed watermark, and any fallback reason. It never includes terminal text.
+The same privacy-safe Diagnostics surface shows the effective `WebGL` or `DOM`
+state beside terminal-stream metadata. It uses terminal IDs and closed fallback
+reasons only; terminal text, cwd, commands, raw errors, and GPU/device details
+are excluded. Executable ownership lives in
+`src/renderer/hooks/use-terminal-webgl.ts` and
+`src/renderer/stores/terminal-renderer-status-store.ts`.
 
 ## Documentation
 

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -227,20 +227,24 @@ interface GitHubAuth {
 }
 
 interface AppSettings {
-  themeMode: 'light' | 'dark' | 'system'
+  settingsSchemaVersion: number
+  terminalEngine: 'xterm' | 'ghostty'
   colorTheme: ColorTheme
   terminalLimit: TerminalLimit
-  terminalRenderMode: 'performance' | 'balanced' | 'quality'
-  glassmorphismEnabled: boolean
-  windowsShell?: WindowsShell
-  uiStyle: 'modern' | 'terminal'
-  terminalStyleOptions: {
-    colorPreset: 'green' | 'blue' | 'white'
-    fontFamily: 'jetbrains-mono' | 'source-code-pro' | 'fira-code' | 'vt323' | 'ibm-plex-mono' | 'space-mono'
-    useBorderChars: boolean
-  }
+  terminalRendererPolicy: 'automatic' | 'prefer-gpu' | 'safe-dom'
+  scrollbackLines?: number
+  terminalFontFamily: TerminalFontId
+  defaultShell?: ShellInfo
+  themeMode?: 'light' | 'dark' | 'system'
+  modernFontFamily?: AppFontId
+  enableContextWindow?: boolean
+  enableContextWindowAdvanced?: boolean
 }
 ```
+
+Effective renderer state and Retry GPU are renderer-local. They are not added
+to `TerminalPlatformDiagnostic` and do not cross IPC; Diagnostics joins the
+local registry with existing main metadata by terminal ID.
 
 ## 5. Security
 

--- a/docs/DB_DESIGN.md
+++ b/docs/DB_DESIGN.md
@@ -53,12 +53,15 @@ erDiagram
     }
 
     APP_SETTINGS {
+        number settingsSchemaVersion
         string themeMode
         string colorTheme
         object terminalLimit
-        string terminalRenderMode
-        boolean glassmorphismEnabled
-        object windowsShell
+        string terminalEngine
+        string terminalRendererPolicy
+        number scrollbackLines
+        string terminalFontFamily
+        object defaultShell
     }
 ```
 
@@ -165,10 +168,20 @@ interface SettingsStoreSchema {
 | `themeMode` | `'light' \| 'dark' \| 'system'` | `'system'` | Color mode preference |
 | `colorTheme` | ColorTheme | `'tokyo-night'` | Color theme selection |
 | `terminalLimit` | TerminalLimit | `{ preset: 9 }` | Max terminals per project |
-| `terminalRenderMode` | `'performance' \| 'balanced' \| 'quality'` | `'balanced'` | WebGL rendering mode |
-| `glassmorphismEnabled` | boolean | `true` | Glass effect toggle |
-| `windowsShell` | WindowsShell | undefined | Default shell (Windows) |
+| `settingsSchemaVersion` | number | `2` | Settings migration schema |
+| `terminalEngine` | `'xterm' \| 'ghostty'` | `'xterm'` | Terminal engine selection; current capability resolution remains xterm |
+| `terminalRendererPolicy` | `'automatic' \| 'prefer-gpu' \| 'safe-dom'` | `'automatic'` | Canonical renderer policy |
+| `scrollbackLines` | number | `20000` | xterm scrollback size, clamped to the supported range |
+| `terminalFontFamily` | TerminalFontId | `'jetbrains-mono'` | Terminal content font |
+| `defaultShell` | ShellInfo | undefined | Persisted cross-platform default shell |
+| `themeMode` | `'light' \| 'dark' \| 'system'` | `'dark'` | Optional color mode preference |
+| `modernFontFamily` | AppFontId | `'system'` | Optional application UI font |
 | `enableContextWindow` | boolean | `true` | Context analyzer enabled (startup-only) |
+| `enableContextWindowAdvanced` | boolean | channel-aware | Advanced context features; enabled by default on prerelease channels |
+
+Schema v2 retires `terminalRenderMode` and `gpuRendererForClaudeTerminals`.
+`src/main/settings/settings-migrations.ts` owns the presence-aware, idempotent
+migration and deletes both retired keys before persistence.
 
 #### E-07: TerminalLimit
 
@@ -235,8 +248,8 @@ Settings validation is performed before saving:
 ```typescript
 // Enum validation
 const VALID_THEME_MODES = ['light', 'dark', 'system']
-const VALID_COLOR_THEMES = ['default', 'dusk', 'lime', ...]
-const VALID_RENDER_MODES = ['performance', 'balanced', 'quality']
+const VALID_COLOR_THEMES = ['tokyo-night', 'catppuccin', 'dracula', 'rose-pine', 'pro-dark']
+const VALID_RENDERER_POLICIES = ['automatic', 'prefer-gpu', 'safe-dom']
 const VALID_TERMINAL_PRESETS = [2, 4, 9, 'custom']
 
 // Custom terminal limit: 1-99 range

--- a/docs/SRD.md
+++ b/docs/SRD.md
@@ -93,7 +93,7 @@
 | FR-06.1 | 7 UI color themes + 5 terminal ANSI palettes | ✅ Complete | S-04 |
 | FR-06.2 | Light/Dark/System mode | ✅ Complete | S-04 |
 | FR-06.3 | Settings slide panel with 4 tabs (Appearance, Terminals, Notifications, Updates) | ✅ Complete | S-04 |
-| FR-06.4 | Terminal rendering mode selector (Performance/Balanced/Quality) with Claude-safe toggle | ✅ Complete | S-04 |
+| FR-06.4 | Diagnostics renderer policy (`Automatic`, `Prefer GPU`, `Compatibility`) with effective per-terminal status and recoverable Retry GPU | ✅ Complete | S-04 |
 | FR-06.5 | Context window analyzer toggle in Terminal Settings | ✅ Complete | S-04 |
 
 ### FR-07: Auto-Update
@@ -162,7 +162,7 @@
 - [x] Telegram mobile control with HTML preview
 - [x] Multi-agent notification detection
 - [x] 7 UI themes + 5 terminal ANSI palettes
-- [x] Terminal rendering modes (Performance/Balanced/Quality)
+- [x] Automatic terminal renderer policy with per-pane fallback and diagnostics
 - [x] Full Git/GitHub integration with visual operations
 - [x] Auto-update system with changelog display
 - [x] WSL shell support with UNC path conversion

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -192,10 +192,10 @@ App
 **Position**: Right edge on landscape (340px wide), bottom edge on portrait (full width)
 
 **Layout**:
-- Tab navigation: Appearance, Terminals, Notifications, Updates
+- Tab navigation: Appearance, Terminals, Notifications, Diagnostics, Agents & Integrations, Updates
 - Theme selector (color theme dropdown for all 5 VibeTerminal themes)
 - Notification settings (Telegram/Discord config)
-- Terminal render mode (Performance/Balanced/Quality)
+- Terminal renderer policy and live renderer status in Diagnostics
 - Terminal limit, default shell (Windows)
 - Update checker with progress bar
 - Save/Cancel buttons
@@ -207,6 +207,14 @@ App
 | Theme Mode | Light/Dark/System | System |
 
 **Source**: `src/renderer/components/settings/`
+
+**Terminal renderer policy** lives in Diagnostics, not Terminal Settings. One
+labelled native radio group offers `Automatic (Recommended)`, `Prefer GPU`, and
+`Compatibility`; the Compatibility description is “Disables WebGL for maximum
+compatibility.” Live rows display terminal ID, effective `WebGL`/`DOM`, closed
+fallback copy, and Retry GPU only for recoverable faults whose desired renderer
+is WebGL. The Settings modal disables the complete form and every modal-owned
+dismissal path while Save is pending.
 
 ## 5. Themes
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -647,7 +647,7 @@ scope: terminal, git, notification, settings, etc.
 ```
 
 Examples:
-- `feat(terminal): add WebGL rendering modes`
+- `feat(terminal): add automatic renderer policy`
 - `fix(notification): prevent pattern spam with debounce`
 - `refactor(sidebar): extract navigation-item component`
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -59,8 +59,8 @@ PTY output
 
 Key pieces:
 
-- `src/renderer/utils/terminal-output-dispatcher.ts` keeps a `Map<terminalId, handler>`
-- `src/renderer/components/terminal/terminal-view.tsx` registers a handler for the terminal it owns
+- `src/renderer/utils/terminal-output-dispatcher.ts` owns token-guarded per-terminal stream state
+- `src/renderer/components/terminal/terminal-view.tsx` registers a handler with its mounted renderer-session token
 - `src/renderer/components/terminal/terminal-output-handler.ts` wraps `write()`, `onOutput`, and visible-output buffering
 - `src/renderer/stores/terminal-output-buffer.ts` stores scrollback in a plain module-level `Map`
 - `src/renderer/stores/app-store.ts` keeps the old facade methods so call sites still read and append output through the store API
@@ -71,6 +71,13 @@ Important behavior:
 - `TerminalPane` restores from `initialOutput ?? useAppStore.getState().getTerminalOutput(terminalId)`
 - `addTerminal()` and `removeTerminal()` clear stale buffers for terminal reuse and cleanup
 - `skipAppendRef` suppresses duplicate appends during restore
+
+Renderer policy navigation:
+
+- `src/renderer/utils/terminal-renderer-policy.ts` — pure desired renderer and closed fallback reasons
+- `src/renderer/hooks/use-terminal-webgl.ts` — sole WebGL lifecycle controller
+- `src/renderer/stores/terminal-renderer-status-store.ts` — renderer-local effective status and retry ownership
+- `src/renderer/components/settings/diagnostics-settings.tsx` — live-ID presentation join and policy controls
 
 ### Terminal UI Flow
 

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -63,18 +63,18 @@ MultiClaude v3.1.0-beta.1 uses the VibeTerminal aesthetic: a minimal, terminal-f
 
 **Note**: Escape key handling is managed by `shortcut-utils.ts` to prevent leakage during project switching.
 
-### Terminal Rendering Modes UI
+### Terminal Renderer Policy UI
 
-Three preset modes (Settings > Terminals > Rendering Mode):
-- **⚡ Performance**: No WebGL, best for 9+ terminals, lower GPU load
-- **⚖️ Balanced** (default): WebGL on active terminal only, balanced experience
-- **✨ Quality**: WebGL always on, best visual clarity
+Settings > Diagnostics owns one keyboard-operable radio group:
 
-**Claude-safe Mode** (Experimental):
-- Badge shows current GPU state: "GPU unavailable" (Performance) | "Claude-safe mode" (safe) | "Claude follows mode" (experimental)
-- When disabled: Claude terminals always use canvas renderer (safer)
-- When enabled: Claude terminals use selected rendering mode (experimental, may have rendering issues)
-- Toggle disabled in Performance mode (GPU off globally)
+- **Automatic (Recommended)**: WebGL for regular shells; safer non-WebGL rendering for Claude and Codex.
+- **Prefer GPU**: attempts WebGL for all terminals and falls back automatically.
+- **Compatibility**: Disables WebGL for maximum compatibility.
+
+Preference and effective state remain separate. Each live terminal row uses its
+ID as the label, displays `WebGL` or `DOM` with fixed fallback copy, and shows
+Retry GPU only for recoverable terminal-local faults. Do not display title,
+cwd, command, transcript, raw error, or GPU/device data.
 
 ### Element Styling Guidelines
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -28,8 +28,8 @@
 |----|-------------|--------|
 | FR-1.1 | Spawn/destroy PTY processes via node-pty; system suspend/resume handling | Complete |
 | FR-1.2 | Grid layout auto-adjusts based on terminal count; configurable terminal limits (2, 4, 9, custom) | Complete |
-| FR-1.3 | Terminal rendering modes: Performance (no WebGL), Balanced (active only), Quality (always on) | Complete |
-| FR-1.4 | Claude-safe mode: experimental toggle for GPU rendering on Claude terminals | Complete |
+| FR-1.3 | Terminal renderer policy: Automatic, Prefer GPU, or Compatibility with terminal-local fallback | Complete |
+| FR-1.4 | Automatic keeps Claude and Codex on safer DOM rendering while regular shells attempt WebGL | Complete |
 | FR-1.5 | Terminal title editing via double-click; Claude mode indicator badge | Complete |
 | FR-1.6 | Windows shell selection: cmd, PowerShell (pwsh), WSL distros with validation and cleanup | Complete |
 | FR-1.7 | Terminal keyboard enhancements: OSC title updates via escape sequences; input buffering; smart scroll with smart scroll-to-bottom button | Complete |
@@ -77,7 +77,7 @@
 | FR-6.1 | 7 UI color themes + Light/Dark/System modes (Default, Dusk, Lime, Ocean, Retro, Neo, Forest) | Complete | Applied to app chrome |
 | FR-6.2 | 5 Terminal ANSI palette themes (Tokyo Night, Catppuccin Mocha, Dracula, Rosé Pine, Pro Dark) | Complete | xterm v6 color integration |
 | FR-6.3 | Settings slide panel with 4 tabs (Appearance, Terminals, Notifications, Updates) | Complete | Modal-free slide from right/bottom |
-| FR-6.4 | Terminal rendering mode selector (Performance/Balanced/Quality) with Claude-safe toggle | Complete | WebGL + GPU control + xterm v6 |
+| FR-6.4 | Diagnostics renderer policy plus effective `DOM`/`WebGL` status and recoverable per-terminal retry | Complete | xterm v6 DOM/WebGL controller |
 | FR-6.5 | Terminal limit presets (2, 4, 9, custom) to constrain concurrent terminals | Complete | Enforced at spawn time |
 | FR-6.6 | Windows shell selector: cmd, PowerShell, WSL distros with persistent storage | Complete | Per-project shell choice |
 | FR-6.7 | Settings pending/saved flow: preview changes before persisting; hasUnsavedChanges tracking | Complete | Field-by-field equality check |
@@ -138,7 +138,7 @@
 - Multi-agent detection (Claude, Codex, Gemini, Aider) in notifications
 - Notification watcher with tool-approval, error, warning, review-needed patterns
 - 7 UI themes + 5 terminal ANSI palettes (Tokyo Night, Catppuccin Mocha, Dracula, Rosé Pine, Pro Dark)
-- Terminal rendering modes (Performance/Balanced/Quality) with Claude-safe toggle
+- Automatic terminal renderer policy with typed per-pane fallback and diagnostics
 - Windows shell selection (cmd, PowerShell, WSL distros) with UNC path conversion
 - System suspend/resume handling with powerMonitor + 2s debounce
 - Vietnamese IME auto-patch with status detection

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -156,6 +156,20 @@ Restore behavior:
 - `skipAppendRef` suppresses duplicate appends during restore
 - `addTerminal()` and `removeTerminal()` clear stale buffer entries for reused or closed terminal IDs
 
+#### Renderer Policy And Session Ownership
+
+`src/renderer/utils/terminal-renderer-policy.ts` owns the pure policy decision.
+`src/renderer/hooks/use-terminal-webgl.ts` is the only production WebGL addon
+constructor and owns lazy allocation, loss-listener setup, one-way session
+fallback, retry, and disposal. Successful WebGL stays attached while a pane is
+hidden or inactive; first allocation remains active-and-visible lazy.
+
+Each mounted renderer receives an opaque session token. Snapshot locks, output
+pause/resume, handler registration, lifecycle subscriptions, and the local
+status/retry registry all validate that token so late work cannot mutate a
+replacement terminal with the same ID. The local registry is joined with main
+terminal diagnostics only in the Diagnostics presentation layer; it adds no IPC.
+
 #### Legacy Raw Buffer (outputBuffer)
 
 `PTYProcess.outputBuffer` is a bounded local restore/diagnostic tail. A separate bounded `notificationTail` serves explicitly enabled Telegram output and smart-summary commands. Neither is the normal UI source of truth; canonical refresh uses the headless snapshot, while renderer live buffering is the failure path when that snapshot is unavailable.
@@ -270,7 +284,7 @@ The current architecture keeps the hot path small:
 - The output buffer is plain module state, not reactive store state
 - One shared IPC listener replaces N per-terminal output subscriptions
 - `TerminalView` owns xterm write timing, scrollback restore, and visible-data bookkeeping
-- Terminal limits and WebGL rendering modes still cap resource usage
+- Terminal limits plus lazy, fallback-capable WebGL allocation cap resource usage
 
 ## Build And Release
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -70,7 +70,7 @@ multiclaude/
 - `@xterm/xterm`: Terminal rendering v6 with keyboard enhancements
 - `@xterm/addon-fit`: Auto-resize with debounce
 - `@xterm/addon-serialize`: Snapshot serialization for warp-style refresh
-- `@xterm/addon-webgl`: GPU rendering (3 modes: Performance/Balanced/Quality)
+- `@xterm/addon-webgl`: Lazy GPU rendering under the Automatic/Prefer GPU/Compatibility policy
 - `zustand`: State management (app + settings + pane-tree + context stores)
 - `tailwindcss`: Styling with CSS variable overrides for 7 themes
 - `@fontsource/*`: Font families with Nerd Font symbol fallbacks
@@ -78,7 +78,7 @@ multiclaude/
 
 ### Shared
 - `@shared/types`: Terminal, Project, Settings, NotificationEvent, TerminalLimit, WindowsShell
-- `@shared/constants`: IPC channels, theme definitions, terminal rendering modes
+- `@shared/constants`: IPC channels, theme definitions, and canonical renderer policy defaults
 
 ### Shared Components
 - `ToggleSwitch`: Reusable settings control for boolean toggles
@@ -118,8 +118,8 @@ multiclaude/
 7. **Terminal Limits**: Configurable per-app (2, 4, 9, custom 1-99), enforced at spawn
 8. **System Suspend/Resume**: powerMonitor pause + 2s debounce resync (prevents SIGTRAP)
 9. **rAF-Coalesced Divider**: Drag updates batched (eliminates 100Hz trackpad bursts)
-10. **Three Rendering Modes**: Performance (no GPU), Balanced (active only), Quality (always)
-11. **Claude-safe Mode**: Toggle to keep Claude terminals on canvas renderer (experimental)
+10. **Renderer Policy**: Automatic (default), Prefer GPU, or Compatibility (`safe-dom`)
+11. **Session-local Fallback**: one xterm.js DOM/WebGL controller owns lazy load, context-loss suppression, retry, and disposal; Claude and Codex resolve to DOM under Automatic
 12. **GitHub CLI for Auth**: Use `gh` CLI for OAuth (proven, maintained)
 13. **Windows Shell Selection**: cmd, PowerShell, WSL distros with validation + UNC conversion
 14. **Context Window Analyzer**: 300ms debounce snapshot, 6-category breakdown, 1h TTL

--- a/scripts/benchmarks/analyze-packaged-terminal-memory.mjs
+++ b/scripts/benchmarks/analyze-packaged-terminal-memory.mjs
@@ -6,6 +6,7 @@ import {
   evaluateMemoryAcceptance,
   readSingleFlag,
   summarizeSteadyStateTrend,
+  validateTerminalEvidence,
   workspaceRelativeEvidenceSource,
 } from './packaged-terminal-soak-lib.mjs'
 
@@ -31,12 +32,12 @@ const results = evidence.results.map(result => {
   return {
     paneCount: result.paneCount,
     elapsedSeconds: result.elapsedSeconds,
-    correctness: result.terminalEvidence.ok,
+    correctness: validateTerminalEvidence(result.terminalEvidence).ok,
     acceptance: evaluateMemoryAcceptance({
       samples,
       paneCount: result.paneCount,
       elapsedSeconds: result.elapsedSeconds,
-      correctness: result.terminalEvidence.ok,
+      correctness: validateTerminalEvidence(result.terminalEvidence).ok,
     }),
     steadyState: {
       mainPrivateMiB: summarizeSteadyStateTrend(samples, 'mainPrivateMiB'),

--- a/scripts/benchmarks/analyze-packaged-terminal-memory.mjs
+++ b/scripts/benchmarks/analyze-packaged-terminal-memory.mjs
@@ -1,13 +1,29 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { evaluateMemoryAcceptance, summarizeSteadyStateTrend } from './packaged-terminal-soak-lib.mjs'
+import {
+  attestSingleSoakEvidence,
+  evaluateMemoryAcceptance,
+  readSingleFlag,
+  summarizeSteadyStateTrend,
+  workspaceRelativeEvidenceSource,
+} from './packaged-terminal-soak-lib.mjs'
 
 const input = process.argv[2]
-if (!input) throw new Error('usage: node analyze-packaged-terminal-memory.mjs <soak-evidence.json>')
+if (!input) {
+  throw new Error('usage: node analyze-packaged-terminal-memory.mjs <soak-evidence.json> --expected-policy=<policy> --expected-pane-count=<1|4|9>')
+}
+const flags = process.argv.slice(3)
+const expectedPolicy = readSingleFlag(flags, 'expected-policy', '')
+const expectedPaneCountValue = readSingleFlag(flags, 'expected-pane-count', '')
+if (!/^(1|4|9)$/.test(expectedPaneCountValue)) {
+  throw new Error('--expected-pane-count must be 1, 4, or 9')
+}
+const expectedPaneCount = Number.parseInt(expectedPaneCountValue, 10)
 const evidence = JSON.parse(fs.readFileSync(path.resolve(input), 'utf8'))
-if (!Array.isArray(evidence.results) || evidence.results.length === 0) {
-  throw new Error('soak evidence must contain at least one result')
+const attestation = attestSingleSoakEvidence(evidence, { expectedPolicy, expectedPaneCount })
+if (!attestation.ok) {
+  throw new Error(`soak evidence attestation failed: ${attestation.failures.join('; ')}`)
 }
 
 const results = evidence.results.map(result => {
@@ -32,5 +48,11 @@ const results = evidence.results.map(result => {
 })
 
 const accepted = results.every(result => result.correctness && result.acceptance.ok)
-process.stdout.write(`${JSON.stringify({ source: path.resolve(input), accepted, results }, null, 2)}\n`)
+process.stdout.write(`${JSON.stringify({
+  source: workspaceRelativeEvidenceSource(input, process.cwd()),
+  expectedPolicy,
+  expectedPaneCount,
+  accepted,
+  results,
+}, null, 2)}\n`)
 if (!accepted) process.exitCode = 1

--- a/scripts/benchmarks/packaged-terminal-soak-lib.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak-lib.mjs
@@ -137,10 +137,17 @@ export function createProfileDirectoryPlan({ profileDirectory, paneCount, makeTe
   }
 }
 
-export function validateRendererEvidence({ terminalIds, statuses, policy }) {
+export function validateRendererEvidence({
+  terminalIds,
+  statuses,
+  policy,
+  safeAgentTerminalIds = [],
+}) {
   const failures = []
   if (!SUPPORTED_RENDERER_POLICIES.has(policy)) failures.push('renderer policy is invalid')
   const expectedIds = new Set(terminalIds)
+  const safeAgentIds = new Set(safeAgentTerminalIds)
+  const observedIds = new Set()
   for (const status of statuses) {
     const keys = Object.keys(status).sort()
     if (keys.join(',') !== 'effective,fallbackReason,terminalId') {
@@ -148,6 +155,8 @@ export function validateRendererEvidence({ terminalIds, statuses, policy }) {
       continue
     }
     if (!expectedIds.has(status.terminalId)) failures.push(`${status.terminalId}: renderer status is not live`)
+    if (observedIds.has(status.terminalId)) failures.push(`${status.terminalId}: duplicate renderer status`)
+    observedIds.add(status.terminalId)
     if (!EFFECTIVE_RENDERERS.has(status.effective)) failures.push(`${status.terminalId}: invalid effective renderer`)
     if (!RENDERER_FALLBACK_REASONS.has(status.fallbackReason)) failures.push(`${status.terminalId}: invalid fallback reason`)
     if (status.effective === 'webgl' && status.fallbackReason !== 'none') {
@@ -156,12 +165,60 @@ export function validateRendererEvidence({ terminalIds, statuses, policy }) {
     if (policy === 'safe-dom' && status.effective !== 'dom') {
       failures.push(`${status.terminalId}: Compatibility must resolve to DOM`)
     }
+    const expectedPolicyReason = policy === 'safe-dom'
+      ? 'policy-safe'
+      : policy === 'automatic' && safeAgentIds.has(status.terminalId)
+        ? 'automatic-agent-safe'
+        : null
+    if (expectedPolicyReason !== null) {
+      if (status.effective !== 'dom' || status.fallbackReason !== expectedPolicyReason) {
+        failures.push(`${status.terminalId}: renderer status contradicts the selected policy`)
+      }
+    } else {
+      const validWebGLResult = status.effective === 'webgl' && status.fallbackReason === 'none'
+      const validWebGLFallback = status.effective === 'dom'
+        && ['webgl-unavailable', 'webgl-load-failed', 'webgl-context-lost'].includes(status.fallbackReason)
+      if (!validWebGLResult && !validWebGLFallback) {
+        failures.push(`${status.terminalId}: renderer status contradicts a WebGL attempt`)
+      }
+    }
   }
   for (const terminalId of terminalIds) {
     if (!statuses.some(status => status.terminalId === terminalId)) {
       failures.push(`${terminalId}: missing renderer status`)
     }
   }
+  return { ok: failures.length === 0, failures }
+}
+
+export function validateRendererCleanupEvidence({
+  originalTerminalIds,
+  closedTerminalId,
+  remainingTerminalIds,
+  registryCount,
+  statuses,
+  policy,
+}) {
+  const failures = []
+  const expectedRemainingIds = originalTerminalIds.filter(id => id !== closedTerminalId)
+  if (!originalTerminalIds.includes(closedTerminalId)) {
+    failures.push('closed terminal was not part of the live renderer set')
+  }
+  if (registryCount !== expectedRemainingIds.length) {
+    failures.push('renderer registry count did not match the remaining terminal count')
+  }
+  if (
+    [...remainingTerminalIds].sort().join(',')
+    !== [...expectedRemainingIds].sort().join(',')
+  ) {
+    failures.push('remaining renderer terminal IDs did not match the live terminal set')
+  }
+  const statusValidation = validateRendererEvidence({
+    terminalIds: expectedRemainingIds,
+    statuses,
+    policy,
+  })
+  failures.push(...statusValidation.failures)
   return { ok: failures.length === 0, failures }
 }
 
@@ -185,6 +242,72 @@ export function attestSingleSoakEvidence(evidence, { expectedPolicy, expectedPan
   if (evidence?.results?.[0]?.paneCount !== expectedPaneCount) {
     failures.push('result pane count mismatch')
   }
+  const result = evidence?.results?.length === 1 ? evidence.results[0] : null
+  if (result) {
+    const terminalEvidence = result.terminalEvidence
+    const terminalIds = terminalEvidence?.terminalIds
+    if (!Array.isArray(terminalIds)
+      || terminalIds.length !== expectedPaneCount
+      || new Set(terminalIds).size !== terminalIds.length) {
+      failures.push('terminal evidence count mismatch')
+    } else {
+      const terminalValidation = validateTerminalEvidence(terminalEvidence)
+      if (!terminalValidation.ok || terminalEvidence.ok !== true) {
+        failures.push('terminal correctness evidence is invalid')
+      }
+      const rendererEvidence = result.rendererEvidence
+      const rendererValidation = validateRendererEvidence({
+        terminalIds,
+        statuses: Array.isArray(rendererEvidence?.statuses) ? rendererEvidence.statuses : [],
+        policy: rendererEvidence?.policy,
+      })
+      const cleanup = rendererEvidence?.cleanup
+      const cleanupValidation = validateRendererCleanupEvidence({
+        originalTerminalIds: terminalIds,
+        closedTerminalId: cleanup?.closedTerminalId,
+        remainingTerminalIds: Array.isArray(cleanup?.remainingTerminalIds)
+          ? cleanup.remainingTerminalIds
+          : [],
+        registryCount: cleanup?.registryCount,
+        statuses: Array.isArray(cleanup?.statuses) ? cleanup.statuses : [],
+        policy: rendererEvidence?.policy,
+      })
+      if (rendererEvidence?.policy !== expectedPolicy
+        || !rendererValidation.ok
+        || rendererEvidence?.ok !== true
+        || cleanup?.ok !== true
+        || !cleanupValidation.ok) {
+        failures.push('renderer evidence is invalid')
+      }
+      if (!Array.isArray(rendererEvidence?.finalStatuses)) {
+        failures.push('final renderer evidence is required')
+      } else {
+        const finalValidation = validateRendererEvidence({
+          terminalIds,
+          statuses: rendererEvidence.finalStatuses,
+          policy: rendererEvidence.policy,
+        })
+        if (!finalValidation.ok) failures.push('final renderer evidence is invalid')
+      }
+    }
+
+    if (!Array.isArray(result.rawAttributionSamples) || result.rawAttributionSamples.length === 0) {
+      failures.push('raw attribution samples are required')
+    } else {
+      for (const sample of result.rawAttributionSamples) {
+        try {
+          validateAttributionSample(sample)
+          if (sample.terminalCount !== expectedPaneCount) {
+            failures.push('attribution sample terminal count mismatch')
+            break
+          }
+        } catch {
+          failures.push('raw attribution sample is invalid')
+          break
+        }
+      }
+    }
+  }
   return { ok: failures.length === 0, failures }
 }
 
@@ -201,7 +324,7 @@ export function evidenceExecutableIdentifier(executablePath, workspacePath) {
   if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
     return relative.split(path.sep).join('/')
   }
-  return `external-artifact/${path.basename(executablePath)}`
+  return 'external-artifact/redacted'
 }
 
 function round(value) {
@@ -377,6 +500,9 @@ export function evaluateMemoryAcceptance({ samples, paneCount, elapsedSeconds, c
   if (correctness !== true) failures.push('terminal correctness failed')
   if (!Number.isInteger(paneCount) || paneCount <= 0) failures.push('paneCount must be a positive integer')
   if (!Number.isFinite(elapsedSeconds) || elapsedSeconds < 1_800) failures.push('memory soak must run for at least 1800 seconds')
+  if (samples.some(sample => sample.terminalCount !== undefined && sample.terminalCount !== paneCount)) {
+    failures.push('attribution sample terminal count mismatch')
+  }
   if (failures.length > 0) return { ok: false, failures }
 
   const startAtMs = elapsedSeconds * 1_000 - 10 * 60_000

--- a/scripts/benchmarks/packaged-terminal-soak-lib.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak-lib.mjs
@@ -1,4 +1,59 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
 const SUPPORTED_PANE_COUNTS = new Set([1, 4, 9])
+const SUPPORTED_RENDERER_POLICIES = new Set(['automatic', 'prefer-gpu', 'safe-dom'])
+const SUPPORTED_SETTINGS_OPERATIONS = new Set(['observe', 'reset'])
+const EFFECTIVE_RENDERERS = new Set(['dom', 'webgl'])
+const RENDERER_FALLBACK_REASONS = new Set([
+  'automatic-agent-safe',
+  'policy-safe',
+  'webgl-unavailable',
+  'webgl-load-failed',
+  'webgl-context-lost',
+  'none',
+])
+
+function resolveThroughExistingAncestor(candidate) {
+  let ancestor = candidate
+  const missingSegments = []
+  while (!fs.existsSync(ancestor)) {
+    const parent = path.dirname(ancestor)
+    if (parent === ancestor) break
+    missingSegments.unshift(path.basename(ancestor))
+    ancestor = parent
+  }
+  return path.resolve(fs.realpathSync(ancestor), ...missingSegments)
+}
+
+function isSameOrAncestor(candidate, target) {
+  const relative = path.relative(candidate, target)
+  return relative === ''
+    || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
+}
+
+function validateExplicitProfileDirectory(candidate) {
+  const physicalCandidate = resolveThroughExistingAncestor(candidate)
+  const physicalHome = resolveThroughExistingAncestor(path.resolve(os.homedir()))
+  const physicalWorkspace = resolveThroughExistingAncestor(path.resolve(process.cwd()))
+  const temporaryRoots = [os.tmpdir()]
+  if (process.platform !== 'win32') temporaryRoots.push('/tmp', '/var/tmp')
+  const physicalTemporaryRoots = temporaryRoots.map(root =>
+    resolveThroughExistingAncestor(path.resolve(root))
+  )
+  const isBroadHomePath = isSameOrAncestor(physicalCandidate, physicalHome)
+  const overlapsWorkspace = isSameOrAncestor(physicalCandidate, physicalWorkspace)
+    || isSameOrAncestor(physicalWorkspace, physicalCandidate)
+  const isBroadTemporaryPath = physicalTemporaryRoots.some(root =>
+    isSameOrAncestor(physicalCandidate, root)
+  )
+
+  if (isBroadHomePath || overlapsWorkspace || isBroadTemporaryPath) {
+    throw new Error('--profile-dir must be a dedicated directory outside broad home, workspace, and temporary roots')
+  }
+}
 
 function positiveInteger(value, flagName) {
   if (!/^[1-9]\d*$/.test(value)) {
@@ -36,6 +91,30 @@ export function parseSoakArguments(argumentsList) {
     throw new Error('--pane-counts must not contain duplicates')
   }
 
+  const rendererPolicy = readSingleFlag(argumentsList, 'renderer-policy', 'automatic')
+  if (!SUPPORTED_RENDERER_POLICIES.has(rendererPolicy)) {
+    throw new Error('--renderer-policy must be automatic, prefer-gpu, or safe-dom')
+  }
+  const settingsOperationValue = readSingleFlag(argumentsList, 'settings-operation', '')
+  if (settingsOperationValue && !SUPPORTED_SETTINGS_OPERATIONS.has(settingsOperationValue)) {
+    throw new Error('--settings-operation must be observe or reset')
+  }
+  const profileDirectoryValue = readSingleFlag(argumentsList, 'profile-dir', '')
+  let profileDirectory = null
+  if (profileDirectoryValue) {
+    if (!path.isAbsolute(profileDirectoryValue)) {
+      throw new Error('--profile-dir must be an absolute path')
+    }
+    profileDirectory = path.resolve(profileDirectoryValue)
+    if (profileDirectory === path.parse(profileDirectory).root) {
+      throw new Error('--profile-dir must not be a filesystem root')
+    }
+    validateExplicitProfileDirectory(profileDirectory)
+    if (paneCounts.length !== 1) {
+      throw new Error('--profile-dir requires exactly one pane count')
+    }
+  }
+
   return {
     paneCounts,
     durationSeconds: positiveInteger(readSingleFlag(argumentsList, 'duration-seconds', '30'), '--duration-seconds'),
@@ -44,7 +123,85 @@ export function parseSoakArguments(argumentsList) {
       readSingleFlag(argumentsList, 'canonical-interval-seconds', '0'),
       '--canonical-interval-seconds',
     ),
+    rendererPolicy,
+    profileDirectory,
+    settingsOperation: settingsOperationValue || null,
   }
+}
+
+export function createProfileDirectoryPlan({ profileDirectory, paneCount, makeTemporaryDirectory }) {
+  if (profileDirectory) return { profileDirectory, cleanup: false }
+  return {
+    profileDirectory: makeTemporaryDirectory(`multiclaude-packaged-soak-${paneCount}-`),
+    cleanup: true,
+  }
+}
+
+export function validateRendererEvidence({ terminalIds, statuses, policy }) {
+  const failures = []
+  if (!SUPPORTED_RENDERER_POLICIES.has(policy)) failures.push('renderer policy is invalid')
+  const expectedIds = new Set(terminalIds)
+  for (const status of statuses) {
+    const keys = Object.keys(status).sort()
+    if (keys.join(',') !== 'effective,fallbackReason,terminalId') {
+      failures.push(`${status.terminalId ?? 'unknown'}: renderer evidence contains unsupported fields`)
+      continue
+    }
+    if (!expectedIds.has(status.terminalId)) failures.push(`${status.terminalId}: renderer status is not live`)
+    if (!EFFECTIVE_RENDERERS.has(status.effective)) failures.push(`${status.terminalId}: invalid effective renderer`)
+    if (!RENDERER_FALLBACK_REASONS.has(status.fallbackReason)) failures.push(`${status.terminalId}: invalid fallback reason`)
+    if (status.effective === 'webgl' && status.fallbackReason !== 'none') {
+      failures.push(`${status.terminalId}: WebGL status must not have a fallback reason`)
+    }
+    if (policy === 'safe-dom' && status.effective !== 'dom') {
+      failures.push(`${status.terminalId}: Compatibility must resolve to DOM`)
+    }
+  }
+  for (const terminalId of terminalIds) {
+    if (!statuses.some(status => status.terminalId === terminalId)) {
+      failures.push(`${terminalId}: missing renderer status`)
+    }
+  }
+  return { ok: failures.length === 0, failures }
+}
+
+export function attestSingleSoakEvidence(evidence, { expectedPolicy, expectedPaneCount }) {
+  const failures = []
+  if (evidence?.failure) failures.push('soak evidence contains a top-level failure')
+  if (!Array.isArray(evidence?.results) || evidence.results.length !== 1) {
+    failures.push('soak evidence must contain exactly one result')
+  }
+  if (!SUPPORTED_RENDERER_POLICIES.has(expectedPolicy)) failures.push('expected renderer policy is invalid')
+  if (!SUPPORTED_PANE_COUNTS.has(expectedPaneCount)) failures.push('expected pane count must be 1, 4, or 9')
+  if (evidence?.environment?.rendererPolicy !== expectedPolicy) {
+    failures.push('renderer policy provenance mismatch')
+  }
+  const provenanceCounts = evidence?.environment?.paneCounts
+  if (!Array.isArray(provenanceCounts)
+    || provenanceCounts.length !== 1
+    || provenanceCounts[0] !== expectedPaneCount) {
+    failures.push('pane count provenance mismatch')
+  }
+  if (evidence?.results?.[0]?.paneCount !== expectedPaneCount) {
+    failures.push('result pane count mismatch')
+  }
+  return { ok: failures.length === 0, failures }
+}
+
+export function workspaceRelativeEvidenceSource(inputPath, workspacePath) {
+  const relative = path.relative(path.resolve(workspacePath), path.resolve(inputPath))
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('soak evidence source must be inside the workspace')
+  }
+  return relative.split(path.sep).join('/')
+}
+
+export function evidenceExecutableIdentifier(executablePath, workspacePath) {
+  const relative = path.relative(path.resolve(workspacePath), path.resolve(executablePath))
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return relative.split(path.sep).join('/')
+  }
+  return `external-artifact/${path.basename(executablePath)}`
 }
 
 function round(value) {

--- a/scripts/benchmarks/packaged-terminal-soak.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak.mjs
@@ -15,6 +15,7 @@ import {
   summarizeProcessSamples,
   validateAttributionSample,
   validateTerminalEvidence,
+  validateRendererCleanupEvidence,
   validateRendererEvidence,
 } from './packaged-terminal-soak-lib.mjs'
 
@@ -186,7 +187,7 @@ async function collectRendererEvidence(window, terminalIds) {
   return statuses
 }
 
-async function verifyRendererStatusCleanup(window, terminalIds) {
+async function verifyRendererStatusCleanup(window, terminalIds, rendererPolicy) {
   const closedTerminalId = terminalIds.at(-1)
   if (!closedTerminalId) throw new Error('renderer cleanup requires a live terminal')
   await window.locator(
@@ -203,8 +204,15 @@ async function verifyRendererStatusCleanup(window, terminalIds) {
   await window.locator('[data-testid="settings-button"]').click()
   await window.locator('[data-testid="settings-tab-diagnostics"]').click()
   const rows = window.locator('[data-renderer-terminal-id]')
+  const diagnostics = window.getByTestId('terminal-stream-diagnostics')
   const statusDeadline = Date.now() + 10_000
-  while (await rows.count() !== expectedLiveCount) {
+  while (
+    await rows.count() !== expectedLiveCount
+    || Number(await diagnostics.getAttribute('data-renderer-registry-count')) !== expectedLiveCount
+    || !await rows.evaluateAll(elements => elements.every(element =>
+      element.getAttribute('data-renderer-effective') !== 'unavailable'
+    ))
+  ) {
     if (Date.now() >= statusDeadline) throw new Error('renderer status did not clean up after terminal close')
     await delay(50)
   }
@@ -214,8 +222,32 @@ async function verifyRendererStatusCleanup(window, terminalIds) {
   const remainingTerminalIds = await rows.evaluateAll(elements =>
     elements.map(element => element.getAttribute('data-renderer-terminal-id')).filter(Boolean)
   )
+  const statuses = await rows.evaluateAll(elements => elements.map(element => ({
+    terminalId: element.getAttribute('data-renderer-terminal-id'),
+    effective: element.getAttribute('data-renderer-effective'),
+    fallbackReason: element.getAttribute('data-renderer-fallback'),
+  })))
+  const registryCount = Number(await diagnostics.getAttribute('data-renderer-registry-count'))
+  const cleanupEvidence = validateRendererCleanupEvidence({
+    originalTerminalIds: terminalIds,
+    closedTerminalId,
+    remainingTerminalIds,
+    registryCount,
+    statuses,
+    policy: rendererPolicy,
+  })
+  if (!cleanupEvidence.ok) {
+    throw new Error(`renderer cleanup evidence failed: ${cleanupEvidence.failures.join('; ')}`)
+  }
   await window.locator('[aria-label="Close Settings"]').click()
-  return { closedTerminalId, expectedLiveCount, remainingTerminalIds, ok: true }
+  return {
+    closedTerminalId,
+    expectedLiveCount,
+    remainingTerminalIds,
+    registryCount,
+    statuses,
+    ok: true,
+  }
 }
 
 async function installStreamProbe(window) {
@@ -494,7 +526,20 @@ async function runPaneConfiguration({
     const streams = await window.evaluate(() => window.__MC_PACKAGED_SOAK__.probe.streams)
     const evidence = validateTerminalEvidence({ terminalIds, streams, liveMarkers, canonicalMarkers })
     if (!evidence.ok) throw new Error(`terminal correctness evidence failed: ${evidence.failures.join('; ')}`)
-    const rendererCleanup = await verifyRendererStatusCleanup(window, terminalIds)
+    const finalRendererStatuses = await collectRendererEvidence(window, terminalIds)
+    const finalRendererEvidence = validateRendererEvidence({
+      terminalIds,
+      statuses: finalRendererStatuses,
+      policy: rendererPolicy,
+    })
+    if (!finalRendererEvidence.ok) {
+      throw new Error(`final renderer evidence failed: ${finalRendererEvidence.failures.join('; ')}`)
+    }
+    const rendererCleanup = await verifyRendererStatusCleanup(
+      window,
+      terminalIds,
+      rendererPolicy,
+    )
 
     return {
       paneCount,
@@ -507,8 +552,9 @@ async function runPaneConfiguration({
       rendererEvidence: {
         policy: rendererPolicy,
         statuses: rendererStatuses,
+        finalStatuses: finalRendererStatuses,
         cleanup: rendererCleanup,
-        ok: true,
+        ok: rendererEvidence.ok && finalRendererEvidence.ok && rendererCleanup.ok,
       },
       settingsEvidence,
       processMetrics: summarizeProcessSamples(processSamples),

--- a/scripts/benchmarks/packaged-terminal-soak.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak.mjs
@@ -7,12 +7,15 @@ import { _electron as electron } from '@playwright/test'
 
 import {
   aggregateCanonicalEvidence,
+  createProfileDirectoryPlan,
+  evidenceExecutableIdentifier,
   parseSoakArguments,
   readSingleFlag,
   summarizeAttributionSamples,
   summarizeProcessSamples,
   validateAttributionSample,
   validateTerminalEvidence,
+  validateRendererEvidence,
 } from './packaged-terminal-soak-lib.mjs'
 
 const DEFAULT_EXECUTABLE = path.resolve('release/mac-arm64/MultiClaude.app/Contents/MacOS/MultiClaude')
@@ -99,6 +102,120 @@ async function installSoakProject(window, projectPath) {
   }, project)
   if (!installed) throw new Error('renderer app store is unavailable')
   await window.waitForSelector('[data-testid="project-tab-packaged-soak-project"]', { timeout: 5_000 })
+}
+
+function redactSettings(settings) {
+  return {
+    settingsSchemaVersion: Number.isSafeInteger(settings?.settingsSchemaVersion)
+      ? settings.settingsSchemaVersion
+      : null,
+    terminalRendererPolicy: ['automatic', 'prefer-gpu', 'safe-dom'].includes(settings?.terminalRendererPolicy)
+      ? settings.terminalRendererPolicy
+      : null,
+    hasRetiredRendererKeys: Boolean(
+      settings
+      && (Object.hasOwn(settings, 'terminalRenderMode')
+        || Object.hasOwn(settings, 'gpuRendererForClaudeTerminals'))
+    ),
+  }
+}
+
+async function prepareSettings(window, rendererPolicy, settingsOperation) {
+  const before = await window.evaluate(() => window.electron.settings.get())
+  let after = before
+  if (settingsOperation === 'reset') {
+    after = await window.evaluate(() => window.electron.settings.reset())
+  } else if (settingsOperation === null) {
+    after = await window.evaluate(policy => window.electron.settings.set({
+      terminalRendererPolicy: policy,
+    }), rendererPolicy)
+  }
+  return { operation: settingsOperation ?? 'apply-policy', before: redactSettings(before), after: redactSettings(after) }
+}
+
+async function collectRendererEvidence(window, terminalIds) {
+  for (const terminalId of terminalIds) {
+    const activated = await window.evaluate(id => {
+      const store = window.__APP_STORE__
+      if (!store) return false
+      store.getState().setActiveTerminal(id)
+      return true
+    }, terminalId)
+    if (!activated) throw new Error('renderer app store is unavailable during pane activation')
+    const activePane = window.locator(`[data-terminal-id="${terminalId}"] .pane-tab.active`)
+    const activationDeadline = Date.now() + 5_000
+    while (await activePane.count() !== 1) {
+      if (Date.now() >= activationDeadline) throw new Error('terminal pane did not become active')
+      await delay(25)
+    }
+    await delay(100)
+    await window.evaluate(() => new Promise(resolve => requestAnimationFrame(() => resolve())))
+    await window.evaluate(() => new Promise(resolve => requestAnimationFrame(() => resolve())))
+    await window.locator('[data-testid="settings-button"]').click()
+    await window.locator('[data-testid="settings-tab-diagnostics"]').click()
+    const activeStatus = window.locator(`[data-renderer-terminal-id="${terminalId}"]`)
+    const statusDeadline = Date.now() + 10_000
+    while (true) {
+      const effective = await activeStatus.getAttribute('data-renderer-effective')
+      const fallback = await activeStatus.getAttribute('data-renderer-fallback')
+      if (effective === 'webgl' || (effective === 'dom' && fallback !== 'none')) break
+      if (Date.now() >= statusDeadline) throw new Error('active terminal never reached a semantic renderer state')
+      await delay(50)
+    }
+    await window.locator('[aria-label="Close Settings"]').click()
+  }
+  await window.locator('[data-testid="settings-button"]').click()
+  await window.locator('[data-testid="settings-tab-diagnostics"]').click()
+  const rows = window.locator('[data-renderer-terminal-id]')
+  const deadline = Date.now() + 10_000
+  while (
+    await rows.count() !== terminalIds.length
+    || !await rows.evaluateAll(elements => elements.every(element =>
+      element.getAttribute('data-renderer-effective') !== 'unavailable'
+    ))
+  ) {
+    if (Date.now() >= deadline) throw new Error('renderer diagnostics did not match live terminal count')
+    await delay(50)
+  }
+  const statuses = await rows.evaluateAll(elements => elements.map(element => ({
+    terminalId: element.getAttribute('data-renderer-terminal-id'),
+    effective: element.getAttribute('data-renderer-effective'),
+    fallbackReason: element.getAttribute('data-renderer-fallback'),
+  })))
+  await window.locator('[aria-label="Close Settings"]').click()
+  return statuses
+}
+
+async function verifyRendererStatusCleanup(window, terminalIds) {
+  const closedTerminalId = terminalIds.at(-1)
+  if (!closedTerminalId) throw new Error('renderer cleanup requires a live terminal')
+  await window.locator(
+    `[data-terminal-id="${closedTerminalId}"] [aria-label="Close terminal"]`,
+  ).click()
+
+  const expectedLiveCount = terminalIds.length - 1
+  const paneDeadline = Date.now() + 10_000
+  while (await window.locator('[data-terminal-id]').count() !== expectedLiveCount) {
+    if (Date.now() >= paneDeadline) throw new Error('closed terminal pane did not leave the live set')
+    await delay(50)
+  }
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await window.locator('[data-testid="settings-tab-diagnostics"]').click()
+  const rows = window.locator('[data-renderer-terminal-id]')
+  const statusDeadline = Date.now() + 10_000
+  while (await rows.count() !== expectedLiveCount) {
+    if (Date.now() >= statusDeadline) throw new Error('renderer status did not clean up after terminal close')
+    await delay(50)
+  }
+  if (await window.locator(`[data-renderer-terminal-id="${closedTerminalId}"]`).count() !== 0) {
+    throw new Error('closed terminal retained a renderer status')
+  }
+  const remainingTerminalIds = await rows.evaluateAll(elements =>
+    elements.map(element => element.getAttribute('data-renderer-terminal-id')).filter(Boolean)
+  )
+  await window.locator('[aria-label="Close Settings"]').click()
+  return { closedTerminalId, expectedLiveCount, remainingTerminalIds, ok: true }
 }
 
 async function installStreamProbe(window) {
@@ -214,8 +331,17 @@ async function runPaneConfiguration({
   sampleIntervalMs,
   canonicalIntervalSeconds,
   executablePath,
+  rendererPolicy,
+  requestedProfileDirectory,
+  settingsOperation,
 }) {
-  const profileDirectory = fs.mkdtempSync(path.join(os.tmpdir(), `multiclaude-packaged-soak-${paneCount}-`))
+  const profilePlan = createProfileDirectoryPlan({
+    profileDirectory: requestedProfileDirectory,
+    paneCount,
+    makeTemporaryDirectory: prefix => fs.mkdtempSync(path.join(os.tmpdir(), prefix)),
+  })
+  const profileDirectory = profilePlan.profileDirectory
+  fs.mkdirSync(profileDirectory, { recursive: true })
   let app
 
   try {
@@ -237,6 +363,21 @@ async function runPaneConfiguration({
     await window.waitForLoadState('domcontentloaded')
     await window.waitForSelector('#root', { state: 'attached', timeout: 10_000 })
     await delay(300)
+    const settingsEvidence = await prepareSettings(window, rendererPolicy, settingsOperation)
+    if (settingsOperation !== null) {
+      return {
+        paneCount,
+        runtime,
+        settingsOnly: true,
+        settingsEvidence,
+      }
+    }
+    if (settingsOperation !== 'observe') {
+      await window.reload()
+      await window.waitForLoadState('domcontentloaded')
+      await window.waitForSelector('#root', { state: 'attached', timeout: 10_000 })
+      await delay(300)
+    }
     await installSoakProject(window, profileDirectory)
     await installStreamProbe(window)
 
@@ -248,6 +389,15 @@ async function runPaneConfiguration({
       throw new Error(`expected ${paneCount} terminals, found ${terminalIds.length}`)
     }
     await waitForTerminalStreams(window, terminalIds)
+    const rendererStatuses = await collectRendererEvidence(window, terminalIds)
+    const rendererEvidence = validateRendererEvidence({
+      terminalIds,
+      statuses: rendererStatuses,
+      policy: rendererPolicy,
+    })
+    if (!rendererEvidence.ok) {
+      throw new Error(`renderer evidence failed: ${rendererEvidence.failures.join('; ')}`)
+    }
 
     const startedAt = Date.now()
     const deadline = startedAt + durationSeconds * 1_000
@@ -344,6 +494,7 @@ async function runPaneConfiguration({
     const streams = await window.evaluate(() => window.__MC_PACKAGED_SOAK__.probe.streams)
     const evidence = validateTerminalEvidence({ terminalIds, streams, liveMarkers, canonicalMarkers })
     if (!evidence.ok) throw new Error(`terminal correctness evidence failed: ${evidence.failures.join('; ')}`)
+    const rendererCleanup = await verifyRendererStatusCleanup(window, terminalIds)
 
     return {
       paneCount,
@@ -353,6 +504,13 @@ async function runPaneConfiguration({
       cycles,
       canonicalChecks,
       terminalEvidence: { terminalIds, streams, liveMarkers, canonicalMarkers, ok: true },
+      rendererEvidence: {
+        policy: rendererPolicy,
+        statuses: rendererStatuses,
+        cleanup: rendererCleanup,
+        ok: true,
+      },
+      settingsEvidence,
       processMetrics: summarizeProcessSamples(processSamples),
       memoryAttribution: summarizeAttributionSamples(attributionSamples),
       rawProcessSamples: processSamples,
@@ -360,7 +518,7 @@ async function runPaneConfiguration({
     }
   } finally {
     if (app) await closeElectronApp(app)
-    fs.rmSync(profileDirectory, { recursive: true, force: true })
+    if (profilePlan.cleanup) fs.rmSync(profileDirectory, { recursive: true, force: true })
   }
 }
 
@@ -380,7 +538,7 @@ async function main() {
       osRelease: os.release(),
       cpuModel: os.cpus()[0]?.model ?? 'unknown',
       totalMemoryGiB: Number((os.totalmem() / 1024 / 1024 / 1024).toFixed(2)),
-      executablePath: path.relative(process.cwd(), executablePath),
+      executablePath: evidenceExecutableIdentifier(executablePath, process.cwd()),
       executableSha256: sha256File(executablePath),
       appArchiveSha256: fs.existsSync(appArchivePath) ? sha256File(appArchivePath) : null,
       appVersion: results[0]?.runtime.appVersion ?? null,
@@ -388,6 +546,9 @@ async function main() {
       runStartedAt,
       runCompletedAt: new Date().toISOString(),
       paneCounts: options.paneCounts,
+      rendererPolicy: options.rendererPolicy,
+      profileOwnership: options.profileDirectory ? 'caller' : 'runner',
+      settingsOperation: options.settingsOperation ?? 'apply-policy',
       durationSecondsPerPaneCount: options.durationSeconds,
       sampleIntervalMs: options.sampleIntervalMs,
       canonicalIntervalSeconds: options.canonicalIntervalSeconds,
@@ -399,15 +560,17 @@ async function main() {
 
   try {
     for (const paneCount of options.paneCounts) {
-      results.push(await runPaneConfiguration({ ...options, paneCount, executablePath }))
+      results.push(await runPaneConfiguration({
+        ...options,
+        paneCount,
+        executablePath,
+        requestedProfileDirectory: options.profileDirectory,
+      }))
       if (outputPath) writeJsonAtomic(outputPath, buildDocument())
     }
   } catch (error) {
     if (outputPath) {
-      writeJsonAtomic(outputPath, buildDocument({
-        message: error instanceof Error ? error.message : String(error),
-        failedAt: new Date().toISOString(),
-      }))
+      writeJsonAtomic(outputPath, buildDocument({ code: 'run-failed', failedAt: new Date().toISOString() }))
     }
     throw error
   }

--- a/scripts/benchmarks/packaged-terminal-soak.spec.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak.spec.mjs
@@ -1,9 +1,16 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
 import test from 'node:test'
 
 import {
   aggregateCanonicalEvidence,
+  attestSingleSoakEvidence,
   evaluateMemoryAcceptance,
+  createProfileDirectoryPlan,
+  evidenceExecutableIdentifier,
   parseSoakArguments,
   readSingleFlag,
   summarizeAttributionSamples,
@@ -11,6 +18,8 @@ import {
   summarizeSteadyStateTrend,
   summarizeTrendWindow,
   validateTerminalEvidence,
+  validateRendererEvidence,
+  workspaceRelativeEvidenceSource,
 } from './packaged-terminal-soak-lib.mjs'
 
 test('aggregateCanonicalEvidence sums multi-terminal snapshot metadata and rejects invalid values', () => {
@@ -38,7 +47,147 @@ test('readSingleFlag returns one string value and rejects ambiguous repeats', ()
 test('parseSoakArguments accepts bounded pane counts and duration', () => {
   assert.deepEqual(
     parseSoakArguments(['--pane-counts=1,4,9', '--duration-seconds=1800', '--sample-interval-ms=5000']),
-    { paneCounts: [1, 4, 9], durationSeconds: 1800, sampleIntervalMs: 5000, canonicalIntervalSeconds: 0 }
+    {
+      paneCounts: [1, 4, 9],
+      durationSeconds: 1800,
+      sampleIntervalMs: 5000,
+      canonicalIntervalSeconds: 0,
+      rendererPolicy: 'automatic',
+      profileDirectory: null,
+      settingsOperation: null,
+    }
+  )
+})
+
+test('parseSoakArguments accepts closed renderer policy, explicit profile, and settings operation', () => {
+  const profileDirectory = path.resolve('/tmp/multiclaude-explicit-profile')
+  assert.deepEqual(parseSoakArguments([
+    '--pane-counts=4',
+    '--renderer-policy=safe-dom',
+    `--profile-dir=${profileDirectory}`,
+    '--settings-operation=observe',
+  ]), {
+    paneCounts: [4],
+    durationSeconds: 30,
+    sampleIntervalMs: 5000,
+    canonicalIntervalSeconds: 0,
+    rendererPolicy: 'safe-dom',
+    profileDirectory,
+    settingsOperation: 'observe',
+  })
+  assert.throws(() => parseSoakArguments(['--renderer-policy=quality']), /renderer-policy/)
+  assert.throws(() => parseSoakArguments(['--profile-dir=relative']), /absolute path/)
+  assert.throws(() => parseSoakArguments([`--profile-dir=${path.parse(process.cwd()).root}`]), /filesystem root/)
+  assert.throws(
+    () => parseSoakArguments([`--profile-dir=${profileDirectory}`, '--pane-counts=1,4']),
+    /exactly one pane count/,
+  )
+  assert.throws(() => parseSoakArguments(['--settings-operation=delete']), /observe or reset/)
+})
+
+test('parseSoakArguments rejects broad or workspace-overlapping explicit profiles', (t) => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'multiclaude-profile-guard-'))
+  const workspaceLink = path.join(temporaryDirectory, 'workspace-link')
+  fs.symlinkSync(process.cwd(), workspaceLink, 'dir')
+  t.after(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }))
+
+  for (const unsafePath of [
+    os.homedir(),
+    path.dirname(os.homedir()),
+    process.cwd(),
+    path.dirname(process.cwd()),
+    path.join(process.cwd(), 'profile-data'),
+    os.tmpdir(),
+    ...(process.platform === 'win32' ? [] : ['/tmp', '/private/tmp', '/var/tmp']),
+    workspaceLink,
+  ]) {
+    assert.throws(
+      () => parseSoakArguments([`--profile-dir=${unsafePath}`, '--pane-counts=1']),
+      /dedicated directory/,
+    )
+  }
+})
+
+test('explicit profile plans are caller-owned while generated profiles are cleaned up', () => {
+  const explicit = path.resolve('/tmp/multiclaude-explicit-profile')
+  assert.deepEqual(createProfileDirectoryPlan({
+    profileDirectory: explicit,
+    paneCount: 1,
+    makeTemporaryDirectory: () => assert.fail('must not allocate a temporary profile'),
+  }), { profileDirectory: explicit, cleanup: false })
+  assert.deepEqual(createProfileDirectoryPlan({
+    profileDirectory: null,
+    paneCount: 9,
+    makeTemporaryDirectory: prefix => `/tmp/${prefix}owned`,
+  }), { profileDirectory: '/tmp/multiclaude-packaged-soak-9-owned', cleanup: true })
+})
+
+test('validateRendererEvidence accepts typed fallback and rejects orphans, arbitrary fields, and policy mismatch', () => {
+  assert.equal(validateRendererEvidence({
+    terminalIds: ['t1', 't2'],
+    policy: 'prefer-gpu',
+    statuses: [
+      { terminalId: 't1', effective: 'webgl', fallbackReason: 'none' },
+      { terminalId: 't2', effective: 'dom', fallbackReason: 'webgl-load-failed' },
+    ],
+  }).ok, true)
+
+  const failed = validateRendererEvidence({
+    terminalIds: ['t1'],
+    policy: 'safe-dom',
+    statuses: [
+      { terminalId: 'orphan', effective: 'webgl', fallbackReason: 'raw driver error', title: 'SECRET' },
+    ],
+  })
+  assert.equal(failed.ok, false)
+  assert.match(failed.failures.join(' '), /unsupported fields|not live|missing renderer status/)
+  assert.doesNotMatch(JSON.stringify(failed), /SECRET|driver error/)
+})
+
+test('attestSingleSoakEvidence rejects failures, substitutions, and multi-result documents', () => {
+  const valid = {
+    environment: { rendererPolicy: 'automatic', paneCounts: [4] },
+    results: [{ paneCount: 4 }],
+  }
+  assert.equal(attestSingleSoakEvidence(valid, {
+    expectedPolicy: 'automatic',
+    expectedPaneCount: 4,
+  }).ok, true)
+
+  for (const evidence of [
+    { ...valid, failure: { code: 'run-failed' } },
+    { ...valid, results: [{ paneCount: 4 }, { paneCount: 9 }] },
+    { ...valid, environment: { rendererPolicy: 'safe-dom', paneCounts: [4] } },
+    { ...valid, environment: { rendererPolicy: 'automatic', paneCounts: [9] } },
+  ]) {
+    assert.equal(attestSingleSoakEvidence(evidence, {
+      expectedPolicy: 'automatic',
+      expectedPaneCount: 4,
+    }).ok, false)
+  }
+})
+
+test('workspaceRelativeEvidenceSource emits no absolute or user-specific source path', () => {
+  const workspace = path.resolve('/workspace/multiclaude')
+  assert.equal(
+    workspaceRelativeEvidenceSource('/workspace/multiclaude/plans/report.json', workspace),
+    'plans/report.json',
+  )
+  assert.throws(
+    () => workspaceRelativeEvidenceSource('/Users/private/report.json', workspace),
+    /inside the workspace/,
+  )
+})
+
+test('evidenceExecutableIdentifier redacts executables outside the workspace', () => {
+  const workspace = path.resolve('/workspace/multiclaude')
+  assert.equal(
+    evidenceExecutableIdentifier('/workspace/multiclaude/release/MultiClaude', workspace),
+    'release/MultiClaude',
+  )
+  assert.equal(
+    evidenceExecutableIdentifier('/tmp/private-build/MultiClaude', workspace),
+    'external-artifact/MultiClaude',
   )
 })
 

--- a/scripts/benchmarks/packaged-terminal-soak.spec.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak.spec.mjs
@@ -18,6 +18,7 @@ import {
   summarizeSteadyStateTrend,
   summarizeTrendWindow,
   validateTerminalEvidence,
+  validateRendererCleanupEvidence,
   validateRendererEvidence,
   workspaceRelativeEvidenceSource,
 } from './packaged-terminal-soak-lib.mjs'
@@ -142,27 +143,139 @@ test('validateRendererEvidence accepts typed fallback and rejects orphans, arbit
   assert.equal(failed.ok, false)
   assert.match(failed.failures.join(' '), /unsupported fields|not live|missing renderer status/)
   assert.doesNotMatch(JSON.stringify(failed), /SECRET|driver error/)
+
+  for (const incompatible of [
+    {
+      policy: 'automatic',
+      statuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'policy-safe' }],
+    },
+    {
+      policy: 'prefer-gpu',
+      statuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'automatic-agent-safe' }],
+    },
+    {
+      policy: 'safe-dom',
+      statuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'webgl-load-failed' }],
+    },
+  ]) {
+    assert.equal(validateRendererEvidence({
+      terminalIds: ['t1'],
+      ...incompatible,
+    }).ok, false)
+  }
+})
+
+test('validateRendererCleanupEvidence requires typed remaining statuses and exact registry cleanup', () => {
+  const valid = {
+    originalTerminalIds: ['t1', 't2'],
+    closedTerminalId: 't2',
+    remainingTerminalIds: ['t1'],
+    registryCount: 1,
+    statuses: [{ terminalId: 't1', effective: 'webgl', fallbackReason: 'none' }],
+    policy: 'automatic',
+  }
+  assert.equal(validateRendererCleanupEvidence(valid).ok, true)
+  assert.equal(validateRendererCleanupEvidence({ ...valid, registryCount: 2 }).ok, false)
+  assert.equal(validateRendererCleanupEvidence({ ...valid, statuses: [] }).ok, false)
 })
 
 test('attestSingleSoakEvidence rejects failures, substitutions, and multi-result documents', () => {
+  const terminalEvidence = {
+    terminalIds: ['t1'],
+    streams: {
+      t1: { firstSequence: 1, lastSequence: 1, chunks: 1, gaps: 0, duplicates: 0, epochs: ['e1'] },
+    },
+    liveMarkers: { t1: true },
+    canonicalMarkers: { t1: true },
+    ok: true,
+  }
+  const rendererEvidence = {
+    policy: 'automatic',
+    statuses: [{ terminalId: 't1', effective: 'webgl', fallbackReason: 'none' }],
+    finalStatuses: [{ terminalId: 't1', effective: 'webgl', fallbackReason: 'none' }],
+    cleanup: {
+      closedTerminalId: 't1',
+      remainingTerminalIds: [],
+      registryCount: 0,
+      statuses: [],
+      ok: true,
+    },
+    ok: true,
+  }
+  const rawAttributionSamples = [{
+    recordedAtMs: 1,
+    mainPrivateMiB: 120,
+    mainSharedMiB: 40,
+    mainHeapUsedMiB: 25,
+    mainHeapTotalMiB: 32,
+    canonicalBytes: 1_000,
+    canonicalWatermark: 10,
+    terminalCount: 1,
+  }]
   const valid = {
-    environment: { rendererPolicy: 'automatic', paneCounts: [4] },
-    results: [{ paneCount: 4 }],
+    environment: { rendererPolicy: 'automatic', paneCounts: [1] },
+    results: [{ paneCount: 1, terminalEvidence, rendererEvidence, rawAttributionSamples }],
   }
   assert.equal(attestSingleSoakEvidence(valid, {
     expectedPolicy: 'automatic',
-    expectedPaneCount: 4,
+    expectedPaneCount: 1,
   }).ok, true)
 
   for (const evidence of [
     { ...valid, failure: { code: 'run-failed' } },
-    { ...valid, results: [{ paneCount: 4 }, { paneCount: 9 }] },
-    { ...valid, environment: { rendererPolicy: 'safe-dom', paneCounts: [4] } },
+    { ...valid, results: [...valid.results, ...valid.results] },
+    { ...valid, environment: { rendererPolicy: 'safe-dom', paneCounts: [1] } },
     { ...valid, environment: { rendererPolicy: 'automatic', paneCounts: [9] } },
+    {
+      ...valid,
+      results: [{
+        ...valid.results[0],
+        rendererEvidence: {
+          ...rendererEvidence,
+          policy: 'safe-dom',
+          statuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'policy-safe' }],
+          finalStatuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'policy-safe' }],
+        },
+      }],
+    },
+    {
+      ...valid,
+      results: [{
+        ...valid.results[0],
+        terminalEvidence: { ...terminalEvidence, ok: true, liveMarkers: { t1: false } },
+      }],
+    },
+    {
+      ...valid,
+      results: [{
+        ...valid.results[0],
+        rawAttributionSamples: [{ ...rawAttributionSamples[0], terminalCount: 9 }],
+      }],
+    },
+    {
+      ...valid,
+      results: [{
+        ...valid.results[0],
+        rendererEvidence: {
+          ...rendererEvidence,
+          statuses: [{ terminalId: 't1', effective: 'dom', fallbackReason: 'policy-safe' }],
+        },
+      }],
+    },
+    {
+      ...valid,
+      results: [{
+        ...valid.results[0],
+        rendererEvidence: {
+          ...rendererEvidence,
+          cleanup: { ...rendererEvidence.cleanup, registryCount: 1, ok: true },
+        },
+      }],
+    },
   ]) {
     assert.equal(attestSingleSoakEvidence(evidence, {
       expectedPolicy: 'automatic',
-      expectedPaneCount: 4,
+      expectedPaneCount: 1,
     }).ok, false)
   }
 })
@@ -187,7 +300,11 @@ test('evidenceExecutableIdentifier redacts executables outside the workspace', (
   )
   assert.equal(
     evidenceExecutableIdentifier('/tmp/private-build/MultiClaude', workspace),
-    'external-artifact/MultiClaude',
+    'external-artifact/redacted',
+  )
+  assert.equal(
+    evidenceExecutableIdentifier('/tmp/private-build/customer-acme-debug-build', workspace),
+    'external-artifact/redacted',
   )
 })
 

--- a/src/__tests__/e2e/fixtures/electron-app.ts
+++ b/src/__tests__/e2e/fixtures/electron-app.ts
@@ -1,4 +1,4 @@
-import { test as base, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test'
+import { test as base, expect, _electron as electron, ElectronApplication, Locator, Page } from '@playwright/test'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
@@ -114,6 +114,73 @@ export const WAIT_TIMES = {
   /** Long delay for complex operations */
   LONG: 500
 } as const
+
+export type RendererPolicyLabel = 'Automatic (Recommended)' | 'Prefer GPU' | 'Compatibility'
+
+export interface VisibleRendererStatus {
+  effective: 'WebGL' | 'DOM' | 'Unavailable'
+  fallback: string
+  retryVisible: boolean
+}
+
+/** Open Settings directly to the renderer policy and semantic status surface. */
+export async function openRendererDiagnostics(window: Page): Promise<void> {
+  const modal = window.getByTestId('settings-modal')
+  if (!await modal.isVisible()) {
+    await window.getByTestId('settings-button').click()
+    await expect(modal).toBeVisible()
+  }
+  await window.getByTestId('settings-tab-diagnostics').click()
+  await expect(window.getByRole('radiogroup', { name: 'Terminal renderer policy' })).toBeVisible()
+}
+
+/** Select a canonical policy through its accessible native radio. */
+export async function selectRendererPolicy(
+  window: Page,
+  policy: RendererPolicyLabel,
+): Promise<void> {
+  const radio = window.getByRole('radio', { name: policy, exact: true })
+  await radio.check()
+  await expect(radio).toBeChecked()
+}
+
+/** Locate one visible Diagnostics row without inspecting xterm internals. */
+export function rendererDiagnosticRow(window: Page, terminalId: string): Locator {
+  return window
+    .getByRole('dialog', { name: 'Settings' })
+    .getByText(terminalId, { exact: true })
+    .locator('xpath=ancestor::div[contains(@class,"rounded-lg")][1]')
+}
+
+/** Read the public renderer status and Retry eligibility shown to the user. */
+export async function readVisibleRendererStatus(
+  window: Page,
+  terminalId: string,
+): Promise<VisibleRendererStatus> {
+  const row = rendererDiagnosticRow(window, terminalId)
+  await expect(row).toBeVisible()
+  const effective = await row
+    .getByText('Renderer', { exact: true })
+    .locator('xpath=following-sibling::dd[1]')
+    .textContent()
+  const fallback = await row
+    .getByText('Renderer fallback', { exact: true })
+    .locator('xpath=following-sibling::dd[1]')
+    .textContent()
+  const retryVisible = await row.getByRole('button', { name: `Retry GPU for ${terminalId}` }).isVisible()
+
+  if (effective !== 'WebGL' && effective !== 'DOM' && effective !== 'Unavailable') {
+    throw new Error('Diagnostics exposed an unknown renderer state')
+  }
+  return { effective, fallback: fallback?.trim() ?? '', retryVisible }
+}
+
+/** Activate a pane through the same user-visible surface used in production. */
+export async function activateTerminalPane(window: Page, terminalId: string): Promise<void> {
+  const pane = window.locator(`[data-terminal-id="${terminalId}"]`)
+  await expect(pane).toBeVisible()
+  await pane.click()
+}
 
 /**
  * Helper to add a new terminal (works whether terminals exist or not).

--- a/src/__tests__/e2e/tests/form-inputs.spec.ts
+++ b/src/__tests__/e2e/tests/form-inputs.spec.ts
@@ -153,20 +153,18 @@ test.describe('Form Inputs', () => {
       await expect(dracula).toHaveAttribute('aria-pressed', 'true')
     })
 
-    test('render mode buttons change selection', async ({ window }) => {
-      await window.locator('[data-testid="settings-tab-terminals"]').click()
-      const renderingCard = window
-        .locator('p:has-text("Rendering Mode")')
-        .locator('xpath=ancestor::div[contains(@class,"settings-card")][1]')
-      const performanceBtn = renderingCard.getByRole('button', { name: /Performance/i })
-      const balancedBtn = renderingCard.getByRole('button', { name: /Balanced/i })
+    test('renderer policy radios support keyboard selection', async ({ window }) => {
+      await window.locator('[data-testid="settings-tab-diagnostics"]').click()
+      const group = window.getByRole('radiogroup', { name: 'Terminal renderer policy' })
+      const automatic = group.getByRole('radio', { name: 'Automatic (Recommended)', exact: true })
+      const preferGpu = group.getByRole('radio', { name: 'Prefer GPU', exact: true })
 
-      await performanceBtn.click()
-      await expect(performanceBtn).toHaveAttribute('aria-pressed', 'true')
+      await automatic.focus()
+      await automatic.press('ArrowDown')
 
-      await balancedBtn.click()
-      await expect(balancedBtn).toHaveAttribute('aria-pressed', 'true')
-      await expect(performanceBtn).toHaveAttribute('aria-pressed', 'false')
+      await expect(preferGpu).toBeChecked()
+      await expect(automatic).not.toBeChecked()
+      await expect(window.getByTestId('settings-save-button')).toBeEnabled()
     })
   })
 })

--- a/src/__tests__/e2e/tests/project-switching.spec.ts
+++ b/src/__tests__/e2e/tests/project-switching.spec.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Page } from '@playwright/test'
 import { test, expect, injectMockProject, addTerminal, WAIT_TIMES } from '../fixtures'
+import {
+  activateTerminalPane,
+  openRendererDiagnostics,
+  readVisibleRendererStatus,
+} from '../fixtures/electron-app'
 import { mockProjects } from '../fixtures/test-data'
 
 const isCI = process.env.CI === 'true'
@@ -11,6 +16,27 @@ const isCI = process.env.CI === 'true'
  * Validates fix for cursor not appearing after project switch.
  */
 test.describe('Project Switching - Cursor Display', () => {
+  async function writeMarker(page: Page, terminalId: string, marker: string): Promise<void> {
+    const characterCodes = [...marker].map(character => character.charCodeAt(0))
+    const octal = characterCodes.map(code => `\\${code.toString(8).padStart(3, '0')}`).join('')
+    await page.evaluate(({ id, windowsCommand, posixCommand }) => {
+      globalThis.window.electron.terminal.write(
+        id,
+        navigator.userAgent.includes('Windows') ? windowsCommand : posixCommand,
+      )
+    }, {
+      id: terminalId,
+      windowsCommand: `powershell -NoProfile -Command "[Console]::WriteLine([char[]](${characterCodes.join(',')}))"\r`,
+      posixCommand: `printf '${octal}\\n'\r`,
+    })
+  }
+
+  async function waitForSnapshotMarker(page: Page, terminalId: string, marker: string): Promise<void> {
+    await expect.poll(async () => page.evaluate(async ({ id, expected }) =>
+      (await globalThis.window.electron.terminal.getSnapshot(id)).ansi.includes(expected),
+    { id: terminalId, expected: marker }), { timeout: 10_000 }).toBe(true)
+  }
+
   async function getTerminalViewportMetricsByTerminalId(page: Page, terminalId: string): Promise<{
     scrollTop: number
     scrollHeight: number
@@ -176,7 +202,7 @@ test.describe('Project Switching - Cursor Display', () => {
     await expect(secondTab).toBeVisible()
     await secondTab.click()
 
-    // Wait for WebGL toggle + focus delay (60ms)
+    // Wait for renderer visibility and focus propagation.
     await window.waitForTimeout(100)
 
     // Verify state: activeProjectId should be second project
@@ -329,7 +355,7 @@ test.describe('Project Switching - Cursor Display', () => {
     await tabC.click()
     await tabA.click()
 
-    // Wait for all state updates and WebGL toggles
+    // Wait for all project and renderer visibility updates.
     await window.waitForTimeout(WAIT_TIMES.STANDARD)
 
     // Final state should be project A
@@ -608,5 +634,56 @@ test.describe('Project Switching - Cursor Display', () => {
     expect(rowFlexAfterReturn).toHaveLength(2)
     expect(rowFlexAfterReturn[0]).toBeCloseTo(rowFlexBeforeSwitch[0], 1)
     expect(rowFlexAfterReturn[1]).toBeCloseTo(rowFlexBeforeSwitch[1], 1)
+  })
+
+  test.skip(isCI, 'PTY-backed switch/output evidence requires a desktop Electron environment')
+  test('A->B->A preserves typed renderer status and exact-once canonical output', async ({ window }) => {
+    test.setTimeout(60_000)
+    const [projectA, projectB] = mockProjects.slice(0, 2)
+    await injectMockProject(window, [projectA, projectB])
+
+    await addTerminal(window)
+    const [terminalA] = await getProjectTerminalIds(window, projectA.id)
+    if (!terminalA) throw new Error('Expected a terminal in project A')
+    await activateTerminalPane(window, terminalA)
+    await writeMarker(window, terminalA, 'MC_SWITCH_A_913')
+    await waitForSnapshotMarker(window, terminalA, 'MC_SWITCH_A_913')
+
+    await window.getByTestId(`project-tab-${projectB.id}`).click()
+    await expect(window.getByRole('button', { name: '+ New Terminal' })).toBeVisible()
+    await addTerminal(window)
+    const [terminalB] = await getProjectTerminalIds(window, projectB.id)
+    if (!terminalB) throw new Error('Expected a terminal in project B')
+    await activateTerminalPane(window, terminalB)
+    await writeMarker(window, terminalB, 'MC_SWITCH_B_913')
+    await waitForSnapshotMarker(window, terminalB, 'MC_SWITCH_B_913')
+
+    await window.getByTestId(`project-tab-${projectA.id}`).click()
+    await activateTerminalPane(window, terminalA)
+    await writeMarker(window, terminalA, 'MC_SWITCH_A_RETURN_913')
+    await waitForSnapshotMarker(window, terminalA, 'MC_SWITCH_A_RETURN_913')
+
+    const snapshots = await window.evaluate(async ({ idA, idB }) => ({
+      a: (await globalThis.window.electron.terminal.getSnapshot(idA)).ansi,
+      b: (await globalThis.window.electron.terminal.getSnapshot(idB)).ansi,
+    }), { idA: terminalA, idB: terminalB })
+    const occurrences = (text: string, marker: string): number => text.split(marker).length - 1
+    expect(occurrences(snapshots.a, 'MC_SWITCH_A_913')).toBe(1)
+    expect(occurrences(snapshots.a, 'MC_SWITCH_A_RETURN_913')).toBe(1)
+    expect(occurrences(snapshots.b, 'MC_SWITCH_B_913')).toBe(1)
+
+    await openRendererDiagnostics(window)
+    for (const terminalId of [terminalA, terminalB]) {
+      await expect.poll(async () =>
+        (await readVisibleRendererStatus(window, terminalId)).effective
+      ).toMatch(/^(WebGL|DOM)$/)
+      const status = await readVisibleRendererStatus(window, terminalId)
+      expect([
+        'none',
+        'WebGL is unavailable in this environment.',
+        'WebGL could not start.',
+        'WebGL context lost.',
+      ]).toContain(status.fallback)
+    }
   })
 })

--- a/src/__tests__/e2e/tests/settings.spec.ts
+++ b/src/__tests__/e2e/tests/settings.spec.ts
@@ -264,13 +264,13 @@ test.describe('Settings Modal', () => {
  * Terminal UI Style E2E tests.
  * Tests terminal style toggle, color presets, fonts, and border options.
  */
-test.describe('Terminal Settings', () => {
+test.describe('Terminal and renderer settings', () => {
   test.beforeEach(async ({ window }) => {
     await injectMockProject(window, [mockProject])
     await window.waitForTimeout(200)
   })
 
-  test('should show rendering mode options in terminal settings', async ({ window }) => {
+  test('keeps renderer policy out of Terminal Settings', async ({ window }) => {
     const settingsButton = window.locator('[data-testid="settings-button"]')
     await settingsButton.click()
     await window.waitForTimeout(300)
@@ -278,67 +278,82 @@ test.describe('Terminal Settings', () => {
     await window.locator('[data-testid="settings-tab-terminals"]').click()
     await window.waitForTimeout(200)
 
-    await expect(window.getByText('Rendering Mode')).toBeVisible()
-    await expect(window.getByRole('button', { name: /Performance/i })).toBeVisible()
-    await expect(window.getByRole('button', { name: /Balanced/i })).toBeVisible()
-    await expect(window.getByRole('button', { name: /Quality/i })).toBeVisible()
+    await expect(window.getByText('Rendering Mode', { exact: true })).toHaveCount(0)
+    await expect(window.getByText('Use GPU renderer for Claude terminals', { exact: true })).toHaveCount(0)
+    await expect(window.getByRole('radio', { name: 'Automatic (Recommended)' })).toHaveCount(0)
   })
 
-  test('should switch terminal render mode to quality', async ({ window }) => {
+  test('shows canonical policy copy and accessible radios in Diagnostics', async ({ window }) => {
     const settingsButton = window.locator('[data-testid="settings-button"]')
     await settingsButton.click()
     await window.waitForTimeout(300)
 
-    await window.locator('[data-testid="settings-tab-terminals"]').click()
+    await window.locator('[data-testid="settings-tab-diagnostics"]').click()
     await window.waitForTimeout(200)
 
-    const renderingCard = window
-      .locator('p:has-text("Rendering Mode")')
-      .locator('xpath=ancestor::div[contains(@class,"settings-card")][1]')
-    const saveButton = window.locator('[data-testid="settings-save-button"]')
-
-    await window.getByRole('button', { name: /Quality/i }).click()
-    await window.waitForTimeout(300)
-
-    await expect(renderingCard.locator('span').first()).toHaveText(/quality/i)
-    await expect(saveButton).toBeEnabled()
+    const group = window.getByRole('radiogroup', { name: 'Terminal renderer policy' })
+    await expect(group).toBeVisible()
+    await expect(group.getByRole('radio', { name: 'Automatic (Recommended)', exact: true })).toBeChecked()
+    await expect(group.getByRole('radio', { name: 'Prefer GPU', exact: true })).toBeVisible()
+    await expect(group.getByRole('radio', { name: 'Compatibility', exact: true })).toBeVisible()
+    await expect(window.getByText('WebGL for regular shells; safer non-WebGL rendering for Claude and Codex.')).toBeVisible()
+    await expect(window.getByText('Attempts WebGL for all terminals and falls back automatically.')).toBeVisible()
+    await expect(window.getByText('Disables WebGL for maximum compatibility.')).toBeVisible()
   })
 
-  test('should disable Claude GPU override in performance mode', async ({ window }) => {
+  test('Cancel restores the saved renderer policy', async ({ window }) => {
     const settingsButton = window.locator('[data-testid="settings-button"]')
     await settingsButton.click()
     await window.waitForTimeout(300)
 
-    await window.locator('[data-testid="settings-tab-terminals"]').click()
+    await window.locator('[data-testid="settings-tab-diagnostics"]').click()
     await window.waitForTimeout(200)
 
-    await window.getByRole('button', { name: /Performance/i }).click()
-    await window.waitForTimeout(300)
+    await window.getByRole('radio', { name: 'Compatibility', exact: true }).check()
+    await expect(window.getByTestId('settings-save-button')).toBeEnabled()
+    await window.getByTestId('settings-cancel-button').click()
+    await expect(window.getByTestId('settings-modal')).not.toBeVisible()
 
-    const gpuToggle = window.locator('[role="switch"]').first()
-    await expect(window.getByText('GPU unavailable')).toBeVisible()
-    await expect(gpuToggle).toBeDisabled()
+    await window.getByTestId('settings-button').click()
+    await window.getByTestId('settings-tab-diagnostics').click()
+    await expect(window.getByRole('radio', { name: 'Automatic (Recommended)', exact: true })).toBeChecked()
   })
 
-  test('should allow Claude GPU override in balanced mode', async ({ window }) => {
+  test('saves the canonical policy and restores it after reload', async ({ window }) => {
     const settingsButton = window.locator('[data-testid="settings-button"]')
     await settingsButton.click()
     await window.waitForTimeout(300)
 
-    await window.locator('[data-testid="settings-tab-terminals"]').click()
+    await window.locator('[data-testid="settings-tab-diagnostics"]').click()
     await window.waitForTimeout(200)
 
-    await window.getByRole('button', { name: /Performance/i }).click()
-    await window.waitForTimeout(200)
-    await window.getByRole('button', { name: /Balanced/i }).click()
-    await window.waitForTimeout(300)
+    await window.getByRole('radio', { name: 'Prefer GPU', exact: true }).check()
+    await window.getByTestId('settings-save-button').click()
+    await expect(window.getByTestId('settings-modal')).not.toBeVisible()
 
-    const gpuToggle = window.locator('[role="switch"]').first()
-    const initialState = await gpuToggle.getAttribute('aria-checked')
-    await expect(gpuToggle).toBeEnabled()
-    await gpuToggle.click()
+    const savedPolicy = await window.evaluate(async () =>
+      (await globalThis.window.electron.settings.get()).terminalRendererPolicy
+    )
+    expect(savedPolicy).toBe('prefer-gpu')
 
-    await expect(gpuToggle).toHaveAttribute('aria-checked', initialState === 'true' ? 'false' : 'true')
+    await window.reload()
+    await window.waitForLoadState('domcontentloaded')
+    await injectMockProject(window, [mockProject])
+    await window.getByTestId('settings-button').click()
+    await window.getByTestId('settings-tab-diagnostics').click()
+    await expect(window.getByRole('radio', { name: 'Prefer GPU', exact: true })).toBeChecked()
+  })
+
+  test('main sanitizes a non-canonical renderer policy', async ({ window }) => {
+    const canonical = await window.evaluate(async () =>
+      globalThis.window.electron.settings.set({
+        terminalRendererPolicy: 'retired-quality',
+      } as never)
+    )
+
+    expect(canonical.terminalRendererPolicy).toBe('automatic')
+    const saved = await window.evaluate(async () => globalThis.window.electron.settings.get())
+    expect(saved.terminalRendererPolicy).toBe('automatic')
   })
 
   test('should update max terminal preset badge', async ({ window }) => {
@@ -397,34 +412,4 @@ test.describe('Terminal Settings', () => {
     await expect(limitCard.locator('span').first()).toHaveText('12 max')
   })
 
-  test('should save and persist terminal settings', async ({ window }) => {
-    const settingsButton = window.locator('[data-testid="settings-button"]')
-    await settingsButton.click()
-    await window.waitForTimeout(300)
-
-    await window.locator('[data-testid="settings-tab-terminals"]').click()
-    await window.waitForTimeout(200)
-
-    await window.getByRole('button', { name: /Quality/i }).click()
-    await window.waitForTimeout(300)
-
-    const saveButton = window.locator('[data-testid="settings-save-button"]')
-    await expect(saveButton).toBeEnabled()
-    await saveButton.click()
-    await window.waitForTimeout(300)
-
-    const modal = window.locator('[data-testid="settings-modal"]')
-    await expect(modal).not.toBeVisible()
-
-    const savedSettings = await window.evaluate(() =>
-      (globalThis as typeof globalThis & {
-        electron: {
-          settings: {
-            get: () => Promise<{ terminalRenderMode: string }>
-          }
-        }
-      }).electron.settings.get()
-    )
-    expect(savedSettings.terminalRenderMode).toBe('quality')
-  })
 })

--- a/src/__tests__/e2e/tests/terminal-grid.spec.ts
+++ b/src/__tests__/e2e/tests/terminal-grid.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect, injectMockProject, addTerminal, clearAllTerminalsForScreenshot, WAIT_TIMES } from '../fixtures'
+import {
+  activateTerminalPane,
+  openRendererDiagnostics,
+  readVisibleRendererStatus,
+} from '../fixtures/electron-app'
 import { mockProject } from '../fixtures/test-data'
 
 // Skip PTY-dependent tests on CI (terminal creation can be unreliable)
@@ -161,6 +166,44 @@ test.describe('Terminal Grid Layout', () => {
     expect(boxes.every(({ width, height }) => width > 200 && height > 100)).toBe(true)
     expect(new Set(boxes.map(({ x }) => x)).size).toBe(3)
     expect(new Set(boxes.map(({ y }) => y)).size).toBe(3)
+  })
+
+  test('1/4/9 activated panes expose stable typed Automatic renderer status', async ({ window }) => {
+    test.setTimeout(90_000)
+
+    for (const targetCount of [1, 4, 9]) {
+      const panes = window.locator('[data-terminal-id]')
+      while (await panes.count() < targetCount) await addTerminal(window)
+      await expect(panes).toHaveCount(targetCount)
+
+      const terminalIds = await panes.evaluateAll(elements =>
+        elements.map(element => element.getAttribute('data-terminal-id')).filter((id): id is string => Boolean(id))
+      )
+      expect(terminalIds).toHaveLength(targetCount)
+      for (const terminalId of terminalIds) await activateTerminalPane(window, terminalId)
+
+      await openRendererDiagnostics(window)
+      await expect(window.getByRole('radio', { name: 'Automatic (Recommended)', exact: true })).toBeChecked()
+
+      for (const terminalId of terminalIds) {
+        await expect.poll(async () =>
+          (await readVisibleRendererStatus(window, terminalId)).effective
+        ).toMatch(/^(WebGL|DOM)$/)
+        const status = await readVisibleRendererStatus(window, terminalId)
+        expect([
+          'none',
+          'WebGL is unavailable in this environment.',
+          'WebGL could not start.',
+          'WebGL context lost.',
+        ]).toContain(status.fallback)
+        expect(status.retryVisible).toBe(
+          status.fallback === 'WebGL could not start.' || status.fallback === 'WebGL context lost.'
+        )
+      }
+
+      await window.getByRole('button', { name: 'Close Settings' }).click()
+      await expect(window.getByTestId('settings-modal')).not.toBeVisible()
+    }
   })
 
   test('grid layout screenshot', async ({ window }) => {

--- a/src/__tests__/e2e/tests/terminal-pane.spec.ts
+++ b/src/__tests__/e2e/tests/terminal-pane.spec.ts
@@ -75,6 +75,7 @@ test.describe('Terminal Pane Interactions', () => {
       const terminalId = await createTerminalForActiveProject(window)
       expect(terminalId).toBeTruthy()
       await window.waitForSelector('[data-terminal-id]', { timeout: 5000 })
+      await window.waitForTimeout(WAIT_TIMES.STANDARD)
     }
   })
 
@@ -169,7 +170,7 @@ test.describe('Terminal Pane Interactions', () => {
 
     // Type new title then press Escape
     await titleInput.fill('Cancelled Title')
-    await titleInput.press('Escape')
+    await window.keyboard.press('Escape')
 
     // Verify original title is restored
     await expect(titleInput).not.toBeVisible({ timeout: 1000 })

--- a/src/__tests__/e2e/tests/terminal-rendering.spec.ts
+++ b/src/__tests__/e2e/tests/terminal-rendering.spec.ts
@@ -1,270 +1,190 @@
-import { test, expect, injectMockProject, addTerminal, clearTerminalForScreenshot, clearAllTerminalsForScreenshot, WAIT_TIMES } from '../fixtures'
-import { mockProject } from '../fixtures/test-data'
 import type { Page } from '@playwright/test'
+import { test, expect, injectMockProject, addTerminal, WAIT_TIMES } from '../fixtures'
+import {
+  activateTerminalPane,
+  openRendererDiagnostics,
+  readVisibleRendererStatus,
+  selectRendererPolicy,
+} from '../fixtures/electron-app'
+import { mockProject } from '../fixtures/test-data'
 
-// Skip PTY-dependent tests on CI (terminal creation can be unreliable)
-const isCI = process.env.CI === 'true'
+// PTY-backed renderer evidence must run on a desktop host. A CI skip is not release evidence.
+const isCI = process.env['CI'] === 'true'
 
-/**
- * Terminal Rendering Mode Tests
- * Tests WebGL rendering modes: performance, balanced, quality.
- * Note: Skipped on CI - PTY creation is unreliable in headless environment.
- */
-
-
-/**
- * Helper to open settings modal.
- */
-async function openSettings(window: Page): Promise<void> {
-  // Click settings button using data-testid
-  const settingsButton = window.locator('[data-testid="settings-button"]')
-  await settingsButton.click()
-  await window.waitForSelector('h2:has-text("Settings")', { timeout: 3000 })
+async function firstTerminalId(window: Page): Promise<string> {
+  const pane = window.locator('[data-terminal-id]').first()
+  await expect(pane).toBeVisible()
+  const terminalId = await pane.getAttribute('data-terminal-id')
+  if (!terminalId) throw new Error('Visible terminal is missing its public terminal ID')
+  return terminalId
 }
 
-/**
- * Helper to navigate to Terminals settings tab.
- */
-async function navigateToTerminalsTab(window: Page): Promise<void> {
-  // Use testid to avoid conflict with sidebar Terminals button
-  const terminalsTab = window.locator('[data-testid="settings-tab-terminals"]')
-  await terminalsTab.click()
-  await window.waitForTimeout(WAIT_TIMES.SHORT)
+async function writeMarker(window: Page, terminalId: string, marker: string): Promise<void> {
+  const characterCodes = [...marker].map(character => character.charCodeAt(0))
+  const octal = characterCodes.map(code => `\\${code.toString(8).padStart(3, '0')}`).join('')
+  await window.evaluate(({ id, windowsCommand, posixCommand }) => {
+    globalThis.window.electron.terminal.write(
+      id,
+      navigator.userAgent.includes('Windows') ? windowsCommand : posixCommand,
+    )
+  }, {
+    id: terminalId,
+    windowsCommand: `powershell -NoProfile -Command "[Console]::WriteLine([char[]](${characterCodes.join(',')}))"\r`,
+    posixCommand: `printf '${octal}\\n'\r`,
+  })
 }
 
-/**
- * Helper to select a rendering mode.
- */
-async function selectRenderingMode(
-  window: Page,
-  mode: 'Performance' | 'Balanced' | 'Quality'
-): Promise<void> {
-  const modeButton = window.getByRole('button', { name: new RegExp(mode, 'i') }).first()
-  await modeButton.click()
-  await window.waitForTimeout(WAIT_TIMES.SHORT)
+async function waitForSnapshotMarker(window: Page, terminalId: string, marker: string): Promise<void> {
+  await expect.poll(async () => window.evaluate(async ({ id, expected }) =>
+    (await globalThis.window.electron.terminal.getSnapshot(id)).ansi.includes(expected),
+  { id: terminalId, expected: marker }), { timeout: 10_000 }).toBe(true)
 }
 
-/**
- * Helper to save and close settings.
- */
-async function saveAndCloseSettings(window: Page): Promise<void> {
-  const saveButton = window.getByTestId('settings-save-button')
-  if (await saveButton.isEnabled()) {
-    await saveButton.click()
-  } else {
-    await window.getByRole('button', { name: 'Close Settings' }).click()
+async function expectGpuEligibleStatus(window: Page, terminalId: string): Promise<void> {
+  await expect.poll(async () =>
+    (await readVisibleRendererStatus(window, terminalId)).effective
+  ).toMatch(/^(WebGL|DOM)$/)
+
+  const status = await readVisibleRendererStatus(window, terminalId)
+  if (status.effective === 'WebGL') {
+    expect(status.fallback).toBe('none')
+    expect(status.retryVisible).toBe(false)
+    return
   }
-  await window.waitForTimeout(WAIT_TIMES.MEDIUM)
+
+  expect([
+    'WebGL is unavailable in this environment.',
+    'WebGL could not start.',
+    'WebGL context lost.',
+  ]).toContain(status.fallback)
+  expect(status.retryVisible).toBe(
+    status.fallback === 'WebGL could not start.' || status.fallback === 'WebGL context lost.'
+  )
 }
 
-test.describe('Terminal Rendering Modes', () => {
-  // Skip entire suite on CI - tests require PTY creation
-  test.skip(isCI, 'Terminal rendering tests require PTY which is unreliable on CI')
+test.describe('Terminal renderer policy', () => {
+  test.skip(isCI, 'PTY-backed renderer evidence requires a desktop Electron environment')
 
   test.beforeEach(async ({ window }) => {
-    // Inject mock project data
     await injectMockProject(window, [mockProject])
-    await window.waitForSelector('#root', { state: 'attached' })
+    await addTerminal(window)
+    await window.waitForSelector('[data-terminal-id]', { timeout: 5_000 })
   })
 
-  test('performance mode disables WebGL', async ({ window }) => {
-    // Open settings and go to terminals
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
+  test('shows typed status across Automatic, Prefer GPU, and Compatibility', async ({ window }) => {
+    const terminalId = await firstTerminalId(window)
+    const markers = ['MC_POLICY_AUTOMATIC_913', 'MC_POLICY_GPU_913', 'MC_POLICY_DOM_913']
+    await activateTerminalPane(window, terminalId)
+    await writeMarker(window, terminalId, markers[0])
+    await waitForSnapshotMarker(window, terminalId, markers[0])
+    await openRendererDiagnostics(window)
 
-    // Select Performance mode
-    await selectRenderingMode(window, 'Performance')
+    await expect(window.getByRole('radio', { name: 'Automatic (Recommended)', exact: true })).toBeChecked()
+    await expectGpuEligibleStatus(window, terminalId)
 
-    const performanceButton = window.getByRole('button', { name: /Performance/i }).first()
-    await expect(performanceButton).toHaveAttribute('aria-pressed', 'true')
+    await window.evaluate((id: string) => {
+      const appStore = (window as unknown as {
+        __APP_STORE__?: {
+          getState: () => { terminals: Array<Record<string, unknown>> }
+          setState: (state: { terminals: Array<Record<string, unknown>> }) => void
+        }
+      }).__APP_STORE__
+      const terminals = appStore?.getState().terminals ?? []
+      appStore?.setState({
+        terminals: terminals.map(terminal =>
+          terminal.id === id ? { ...terminal, agentType: 'claude' } : terminal
+        ),
+      })
+    }, terminalId)
 
-    // Verify description
-    const description = performanceButton.locator('span:has-text("No WebGL")')
-    await expect(description).toBeVisible()
-
-    await saveAndCloseSettings(window)
-
-    // Create a terminal to verify rendering if none exist
-    const initialCount = await window.locator('[data-terminal-id]').count()
-    if (initialCount === 0) {
-      await addTerminal(window)
-      await window.waitForSelector('[data-terminal-id]', { timeout: 5000 })
-    }
-
-    // Terminal should render (in performance mode, no WebGL canvas)
-    const terminalPane = window.locator('[data-terminal-id]').first()
-    await expect(terminalPane).toBeVisible()
-
-    // Clear terminal and inject fixed prompt for consistent screenshot
-    await clearTerminalForScreenshot(window, 0)
-
-    // Take screenshot for visual regression
-    await expect(terminalPane).toHaveScreenshot('terminal-performance-mode.png', {
-      maxDiffPixelRatio: 0.02
+    await expect.poll(async () => readVisibleRendererStatus(window, terminalId)).toMatchObject({
+      effective: 'DOM',
+      fallback: 'Automatic uses safer rendering for this agent.',
+      retryVisible: false,
     })
+
+    await selectRendererPolicy(window, 'Prefer GPU')
+    await expectGpuEligibleStatus(window, terminalId)
+    await writeMarker(window, terminalId, markers[1])
+    await waitForSnapshotMarker(window, terminalId, markers[1])
+
+    await selectRendererPolicy(window, 'Compatibility')
+    await expect.poll(async () => readVisibleRendererStatus(window, terminalId)).toMatchObject({
+      effective: 'DOM',
+      fallback: 'Compatibility disables WebGL.',
+      retryVisible: false,
+    })
+    await writeMarker(window, terminalId, markers[2])
+    await waitForSnapshotMarker(window, terminalId, markers[2])
+
+    await window.getByTestId('settings-save-button').click()
+    const snapshot = await window.evaluate(async id =>
+      (await globalThis.window.electron.terminal.getSnapshot(id)).ansi,
+    terminalId)
+    for (const marker of markers) {
+      expect(snapshot.split(marker)).toHaveLength(2)
+    }
+    await window.locator(`[data-terminal-id="${terminalId}"] [aria-label="Close terminal"]`).click()
+    await expect(window.locator(`[data-terminal-id="${terminalId}"]`)).toHaveCount(0)
+    await openRendererDiagnostics(window)
+    await expect(window.getByText(terminalId, { exact: true })).toHaveCount(0)
+    await expect(window.getByText('No active terminals.', { exact: true })).toBeVisible()
   })
 
-  test('balanced mode uses WebGL on active terminal only', async ({ window }) => {
-    // Open settings and go to terminals
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
+  test('sanitizes an unknown main fallback reason in the Electron surface', async ({ app, window }) => {
+    const terminalId = await firstTerminalId(window)
+    await app.evaluate(({ ipcMain }, id) => {
+      ipcMain.removeHandler('terminal:get-diagnostics')
+      ipcMain.handle('terminal:get-diagnostics', () => [{
+        terminalId: id,
+        provider: null,
+        engine: 'xterm',
+        backend: 'unavailable',
+        backendAvailable: false,
+        lastSequence: 0,
+        watermark: 0,
+        fallbackReason: 'SECRET raw GPU driver and command text',
+      }])
+    }, terminalId)
 
-    // Select Balanced mode
-    await selectRenderingMode(window, 'Balanced')
-
-    const balancedButton = window.getByRole('button', { name: /Balanced/i }).first()
-    await expect(balancedButton).toHaveAttribute('aria-pressed', 'true')
-
-    // Verify description
-    const description = balancedButton.locator('span:has-text("WebGL only for active")')
-    await expect(description).toBeVisible()
-
-    await saveAndCloseSettings(window)
-
-    // Create terminals if none exist
-    const initialCount = await window.locator('[data-terminal-id]').count()
-    if (initialCount === 0) {
-      await addTerminal(window)
-      await window.waitForSelector('[data-terminal-id]', { timeout: 5000 })
-    }
-
-    // Ensure we have at least 2 terminals
-    const currentCount = await window.locator('[data-terminal-id]').count()
-    if (currentCount < 2) {
-      await addTerminal(window)
-    }
-
-    // Verify at least 2 terminals visible
-    const terminalCount = await window.locator('[data-terminal-id]').count()
-    expect(terminalCount).toBeGreaterThanOrEqual(2)
-
-    // Clear all terminals and inject fixed prompt for consistent screenshot
-    await clearAllTerminalsForScreenshot(window)
-
-    // Take screenshot
-    const gridArea = window.getByRole('region', {
-      name: `Terminal grid for project ${mockProject.id}`
-    })
-    await expect(gridArea).toHaveScreenshot('terminal-balanced-mode.png', {
-      maxDiffPixelRatio: 0.02
-    })
+    await openRendererDiagnostics(window)
+    await expect(window.getByText('Backend unavailable', { exact: true })).toBeVisible()
+    await expect(window.getByText(/SECRET raw GPU driver/)).toHaveCount(0)
   })
 
-  test('quality mode enables WebGL always', async ({ window }) => {
-    // Open settings and go to terminals
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
+  test('Compatibility persists and keeps Retry unavailable after reload', async ({ window }) => {
+    const terminalId = await firstTerminalId(window)
+    await activateTerminalPane(window, terminalId)
+    await openRendererDiagnostics(window)
+    await selectRendererPolicy(window, 'Compatibility')
+    await window.getByTestId('settings-save-button').click()
+    await expect(window.getByTestId('settings-modal')).not.toBeVisible()
 
-    // Select Quality mode
-    await selectRenderingMode(window, 'Quality')
-
-    const qualityButton = window.getByRole('button', { name: /Quality/i }).first()
-    await expect(qualityButton).toHaveAttribute('aria-pressed', 'true')
-
-    // Verify description
-    const description = qualityButton.locator('span:has-text("WebGL always")')
-    await expect(description).toBeVisible()
-
-    await saveAndCloseSettings(window)
-
-    // Create a terminal if none exist
-    const initialCount = await window.locator('[data-terminal-id]').count()
-    if (initialCount === 0) {
-      await addTerminal(window)
-      await window.waitForSelector('[data-terminal-id]', { timeout: 5000 })
-    }
-
-    // Terminal should be visible
-    const terminalPane = window.locator('[data-terminal-id]').first()
-    await expect(terminalPane).toBeVisible()
-
-    // Clear terminal and inject fixed prompt for consistent screenshot
-    await clearTerminalForScreenshot(window, 0)
-
-    // Take screenshot
-    await expect(terminalPane).toHaveScreenshot('terminal-quality-mode.png', {
-      maxDiffPixelRatio: 0.02
-    })
-  })
-
-  test('rendering mode persists after page reload', async ({ window }) => {
-    // Set to performance mode
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
-    await selectRenderingMode(window, 'Performance')
-    await saveAndCloseSettings(window)
-
-    // Reload the page
     await window.reload()
     await window.waitForLoadState('domcontentloaded')
-    await window.waitForSelector('#root', { state: 'attached' })
+    await injectMockProject(window, [mockProject])
+    await openRendererDiagnostics(window)
 
-    // Open settings and check if Performance is still selected
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
-
-    // Verify Performance is selected
-    const performanceButton = window.getByRole('button', { name: /Performance/i }).first()
-    await expect(performanceButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(window.getByRole('radio', { name: 'Compatibility', exact: true })).toBeChecked()
+    const savedPolicy = await window.evaluate(async () =>
+      (await globalThis.window.electron.settings.get()).terminalRendererPolicy
+    )
+    expect(savedPolicy).toBe('safe-dom')
+    await expect(window.getByRole('button', { name: /Retry GPU/ })).toHaveCount(0)
   })
 
-  test('terminal settings section displays correctly', async ({ window }) => {
-    // Open settings
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
+  test('retains unrelated max-terminal behavior', async ({ window }) => {
+    await window.getByTestId('settings-button').click()
+    await window.getByTestId('settings-tab-terminals').click()
 
-    // Verify section header
-    const sectionHeader = window.locator('h3:has-text("Terminals")')
-    await expect(sectionHeader).toBeVisible()
-
-    // Verify "Rendering Mode" subsection
-    const renderingLabel = window.getByText('Rendering Mode', { exact: true })
-    await expect(renderingLabel).toBeVisible()
-
-    // Verify all three mode buttons exist
-    const performanceBtn = window.getByRole('button', { name: /Performance/i }).first()
-    const balancedBtn = window.getByRole('button', { name: /Balanced/i }).first()
-    const qualityBtn = window.getByRole('button', { name: /Quality/i }).first()
-
-    await expect(performanceBtn).toBeVisible()
-    await expect(balancedBtn).toBeVisible()
-    await expect(qualityBtn).toBeVisible()
-
-    // Take screenshot of terminal settings
-    const settingsContent = window
-      .getByRole('dialog', { name: 'Settings' })
-      .locator('.overflow-y-scroll')
-    await expect(settingsContent).toHaveScreenshot('terminal-settings-panel.png', {
-      maxDiffPixelRatio: 0.02
-    })
-  })
-
-  test('max terminals limit setting works', async ({ window }) => {
-    // Open settings
-    await openSettings(window)
-    await navigateToTerminalsTab(window)
-
-    // Verify terminal limit section exists
     const limitLabel = window.getByText('Max Terminals per Project', { exact: true })
     await expect(limitLabel).toBeVisible()
-
-    // Click on preset "4"
     const preset4Button = window.getByRole('button', { name: '4', exact: true })
     await preset4Button.click()
-    await window.waitForTimeout(WAIT_TIMES.SHORT)
     await expect(preset4Button).toHaveAttribute('aria-pressed', 'true')
+    await window.getByTestId('settings-save-button').click()
+    await window.waitForTimeout(WAIT_TIMES.SHORT)
 
-    await saveAndCloseSettings(window)
-
-    // Create a terminal if none exist
-    const initialCount = await window.locator('[data-terminal-id]').count()
-    if (initialCount === 0) {
-      await addTerminal(window)
-      await window.waitForSelector('[data-terminal-id]', { timeout: 5000 })
-    }
-
-    // Terminal should be created
-    const terminalCount = await window.locator('[data-terminal-id]').count()
-    expect(terminalCount).toBeGreaterThanOrEqual(1)
+    await expect(window.locator('[data-terminal-id]')).toHaveCount(1)
   })
 })

--- a/src/__tests__/e2e/tests/terminal-scrollback.spec.ts
+++ b/src/__tests__/e2e/tests/terminal-scrollback.spec.ts
@@ -61,8 +61,13 @@ test.describe('Terminal Scrollback', () => {
       `[data-terminal-id="${terminalId}"] .xterm-helper-textarea`
     )
     await terminalInput.focus()
-    for (let step = 0; step < 10; step += 1) {
+    for (let step = 0; step < 30; step += 1) {
+      const previousViewportY = (await getTerminalDebugSnapshot(window, terminalId))?.viewportY
+      if (previousViewportY === 0) break
       await window.keyboard.press('Shift+PageUp')
+      await expect.poll(async () => {
+        return (await getTerminalDebugSnapshot(window, terminalId))?.viewportY ?? previousViewportY
+      }).toBeLessThan(previousViewportY ?? Number.POSITIVE_INFINITY)
     }
     await expect.poll(async () => {
       return (await getTerminalDebugSnapshot(window, terminalId))?.viewportY

--- a/src/main/settings/__tests__/settings-migration-fixtures.ts
+++ b/src/main/settings/__tests__/settings-migration-fixtures.ts
@@ -9,6 +9,32 @@ export interface SettingsMigrationFixture {
 
 export const SETTINGS_MIGRATION_FIXTURES: readonly SettingsMigrationFixture[] = [
   {
+    name: 'legacy compatibility renderer selection',
+    payload: {
+      settingsSchemaVersion: 1,
+      terminalRenderMode: 'performance',
+      gpuRendererForClaudeTerminals: true,
+    },
+    preserved: {
+      settingsSchemaVersion: 2,
+      terminalRendererPolicy: 'safe-dom',
+    },
+    legacyKeys: ['terminalRenderMode', 'gpuRendererForClaudeTerminals'],
+  },
+  {
+    name: 'legacy quality renderer selection',
+    payload: {
+      settingsSchemaVersion: 1,
+      terminalRenderMode: 'quality',
+      gpuRendererForClaudeTerminals: false,
+    },
+    preserved: {
+      settingsSchemaVersion: 2,
+      terminalRendererPolicy: 'prefer-gpu',
+    },
+    legacyKeys: ['terminalRenderMode', 'gpuRendererForClaudeTerminals'],
+  },
+  {
     name: 'supported appearance and terminal selections',
     payload: {
       themeMode: 'system',

--- a/src/main/settings/__tests__/settings-migration-transaction.spec.ts
+++ b/src/main/settings/__tests__/settings-migration-transaction.spec.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import Store from 'electron-store'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SettingsStore } from '../settings-store'
 import {
   beginSettingsMigration,
   confirmSettingsMigrationReady,
@@ -6,7 +8,43 @@ import {
 } from '../settings-migration-transaction'
 
 const backup = { settingsSchemaVersion: 0, colorTheme: 'default' }
-const candidate = { settingsSchemaVersion: 1, colorTheme: 'tokyo-night' }
+const candidate = {
+  settingsSchemaVersion: 2,
+  colorTheme: 'tokyo-night',
+  terminalRendererPolicy: 'automatic',
+}
+
+interface DiskShape {
+  settings?: Record<string, unknown>
+  settingsMigration: ReturnType<typeof beginSettingsMigration> | null
+}
+
+interface StorePrototype {
+  get(this: Store<DiskShape>, key: string): unknown
+  set(this: Store<DiskShape>, key: string, value: unknown): void
+}
+
+const storePrototype = Store.prototype as unknown as StorePrototype
+
+function seedDisk(
+  cwd: string,
+  settings: Record<string, unknown>,
+): Store<DiskShape> {
+  process.env['MULTICLAUDE_TEST_STORE_PATH'] = cwd
+  const disk = new Store<DiskShape>({
+    name: 'multiclaude-settings',
+    cwd,
+    defaults: { settingsMigration: null },
+  })
+  disk.set('settings', structuredClone(settings))
+  disk.set('settingsMigration', null)
+  return disk
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete process.env['MULTICLAUDE_TEST_STORE_PATH']
+})
 
 describe('settings migration transaction', () => {
   it.each(['backup-written', 'candidate-written'] as const)(
@@ -57,5 +95,118 @@ describe('settings migration transaction', () => {
     expect(pending.backup).toEqual(backup)
     expect(pending.candidate).toEqual(candidate)
     expect(confirmSettingsMigrationReady(pending)?.phase).toBe('app-ready-confirmed')
+  })
+
+  it('backs up the raw schema-v1 record and canonicalizes an interrupted restore in the next launch', () => {
+    const cwd = 'settings-renderer-raw-backup'
+    const raw = {
+      settingsSchemaVersion: 1,
+      terminalRenderMode: 'quality',
+      gpuRendererForClaudeTerminals: false,
+      colorTheme: 'dracula',
+    }
+    const disk = seedDisk(cwd, raw)
+
+    const firstLaunch = new SettingsStore().getSettings()
+    const firstTransaction = disk.get('settingsMigration')
+
+    expect(firstLaunch.terminalRendererPolicy).toBe('prefer-gpu')
+    expect(firstTransaction?.backup).toEqual(raw)
+    expect(firstTransaction?.backup).not.toHaveProperty('terminalRendererPolicy')
+
+    const recoveryLaunch = new SettingsStore().getSettings()
+    const recoveryTransaction = disk.get('settingsMigration')
+
+    expect(recoveryLaunch.terminalRendererPolicy).toBe('prefer-gpu')
+    expect(recoveryLaunch).not.toHaveProperty('terminalRenderMode')
+    expect(recoveryTransaction?.phase).toBe('candidate-written')
+    expect(recoveryTransaction?.backup).toEqual(raw)
+  })
+
+  it.each([
+    ['backup transaction write', 'backup-written'],
+    ['candidate transaction write', 'candidate-written'],
+    ['candidate settings write', 'settings'],
+  ] as const)(
+    'fails closed after one %s failure and recovers on the next launch',
+    (_label, failureBoundary) => {
+      const cwd = `settings-renderer-write-failure-${failureBoundary}`
+      const raw = {
+        settingsSchemaVersion: 1,
+        terminalRenderMode: 'performance',
+        gpuRendererForClaudeTerminals: true,
+      }
+      const disk = seedDisk(cwd, raw)
+      const originalSet = storePrototype.set
+      let candidateWrites = 0
+
+      vi.spyOn(storePrototype, 'set').mockImplementation(function (
+        this: Store<DiskShape>,
+        key: string,
+        value: unknown,
+      ) {
+        const record = value as Record<string, unknown> | null
+        if (key === 'settings' && record?.terminalRendererPolicy) candidateWrites += 1
+        const shouldFail =
+          (failureBoundary === 'backup-written'
+            && key === 'settingsMigration'
+            && record?.phase === 'backup-written')
+          || (failureBoundary === 'candidate-written'
+            && key === 'settingsMigration'
+            && record?.phase === 'candidate-written')
+          || (failureBoundary === 'settings'
+            && key === 'settings'
+            && record?.terminalRendererPolicy !== undefined)
+        if (shouldFail) throw new Error('private storage failure detail')
+        return originalSet.call(this, key, value)
+      })
+
+      expect(() => new SettingsStore()).toThrow(
+        'Settings migration failed; restart MultiClaude to retry.',
+      )
+      expect(candidateWrites).toBeLessThanOrEqual(1)
+
+      vi.restoreAllMocks()
+      const recovered = new SettingsStore().getSettings()
+
+      expect(recovered.terminalRendererPolicy).toBe('safe-dom')
+      expect(recovered).not.toHaveProperty('terminalRenderMode')
+      expect(disk.get('settingsMigration')?.backup).toEqual(raw)
+    },
+  )
+
+  it('retains recovery state and aborts when candidate read-back does not match', () => {
+    const cwd = 'settings-renderer-candidate-mismatch'
+    const raw = {
+      settingsSchemaVersion: 1,
+      terminalRenderMode: 'balanced',
+      gpuRendererForClaudeTerminals: true,
+    }
+    const disk = seedDisk(cwd, raw)
+    const originalGet = storePrototype.get
+    let settingsReads = 0
+
+    vi.spyOn(storePrototype, 'get').mockImplementation(function (
+      this: Store<DiskShape>,
+      key: string,
+    ) {
+      const value = originalGet.call(this, key)
+      if (key === 'settings' && ++settingsReads === 2) {
+        return { ...(value as Record<string, unknown>), terminalRendererPolicy: 'safe-dom' }
+      }
+      return value
+    })
+
+    expect(() => new SettingsStore()).toThrow(
+      'Settings migration failed; restart MultiClaude to retry.',
+    )
+    expect(settingsReads).toBe(2)
+    expect(disk.get('settingsMigration')?.backup).toEqual(raw)
+
+    vi.restoreAllMocks()
+    const recovered = new SettingsStore().getSettings()
+
+    expect(recovered.terminalRendererPolicy).toBe('prefer-gpu')
+    expect(recovered).not.toHaveProperty('terminalRenderMode')
   })
 })

--- a/src/main/settings/__tests__/settings-migrations.spec.ts
+++ b/src/main/settings/__tests__/settings-migrations.spec.ts
@@ -4,6 +4,107 @@ import { THEMES } from '@shared/constants'
 
 describe('migrateSettings', () => {
   it.each([
+    ['performance', undefined, 'safe-dom'],
+    ['performance', false, 'safe-dom'],
+    ['performance', true, 'safe-dom'],
+    ['balanced', undefined, 'automatic'],
+    ['balanced', false, 'automatic'],
+    ['balanced', true, 'prefer-gpu'],
+    ['quality', undefined, 'prefer-gpu'],
+    ['quality', false, 'prefer-gpu'],
+    ['quality', true, 'prefer-gpu'],
+  ])(
+    'maps legacy renderer mode %s with GPU override %s to %s',
+    (terminalRenderMode, gpuRendererForClaudeTerminals, expected) => {
+      const migrated = migrateSettings({
+        terminalRenderMode,
+        ...(gpuRendererForClaudeTerminals === undefined
+          ? {}
+          : { gpuRendererForClaudeTerminals }),
+      })
+
+      expect(migrated.terminalRendererPolicy).toBe(expected)
+      expect(migrated).not.toHaveProperty('terminalRenderMode')
+      expect(migrated).not.toHaveProperty('gpuRendererForClaudeTerminals')
+    },
+  )
+
+  it.each([undefined, null, 'unknown', { mode: 'quality' }])(
+    'does not synthesize a policy for malformed legacy mode %j in a partial record',
+    (terminalRenderMode) => {
+      const migrated = migrateSettings(
+        terminalRenderMode === undefined ? {} : { terminalRenderMode },
+      )
+
+      expect(migrated).not.toHaveProperty('terminalRendererPolicy')
+      expect(migrated).not.toHaveProperty('terminalRenderMode')
+    },
+  )
+
+  it('uses a literal true legacy GPU override without a valid legacy mode', () => {
+    expect(migrateSettings({ gpuRendererForClaudeTerminals: true })).toMatchObject({
+      settingsSchemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+      terminalRendererPolicy: 'prefer-gpu',
+    })
+  })
+
+  it('preserves a valid canonical policy over contradictory legacy keys', () => {
+    const migrated = migrateSettings({
+      terminalRendererPolicy: 'automatic',
+      terminalRenderMode: 'performance',
+      gpuRendererForClaudeTerminals: true,
+    })
+
+    expect(migrated.terminalRendererPolicy).toBe('automatic')
+    expect(migrated).not.toHaveProperty('terminalRenderMode')
+    expect(migrated).not.toHaveProperty('gpuRendererForClaudeTerminals')
+  })
+
+  it('never derives a schema-v2 policy from stale legacy keys', () => {
+    const migrated = migrateSettings({
+      settingsSchemaVersion: 2,
+      terminalRenderMode: 'quality',
+      gpuRendererForClaudeTerminals: true,
+    })
+
+    expect(migrated).not.toHaveProperty('terminalRendererPolicy')
+    expect(migrated).not.toHaveProperty('terminalRenderMode')
+    expect(migrated).not.toHaveProperty('gpuRendererForClaudeTerminals')
+  })
+
+  it('does not mutate its input and is deep-equal on a second pass', () => {
+    const raw = {
+      settingsSchemaVersion: 1,
+      terminalRenderMode: 'balanced',
+      gpuRendererForClaudeTerminals: true,
+      nested: { preserved: true },
+    }
+    const original = structuredClone(raw)
+    const first = migrateSettings(raw)
+
+    expect(raw).toEqual(original)
+    expect(migrateSettings(first)).toEqual(first)
+  })
+
+  it('ignores inherited renderer fields and uses only own properties', () => {
+    const inherited = {
+      settingsSchemaVersion: 2,
+      terminalRendererPolicy: 'prefer-gpu',
+      terminalRenderMode: 'quality',
+      gpuRendererForClaudeTerminals: true,
+    }
+    const raw = Object.assign(Object.create(inherited) as Record<string, unknown>, {
+      terminalRenderMode: 'balanced',
+    })
+
+    const migrated = migrateSettings(raw)
+
+    expect(migrated.terminalRendererPolicy).toBe('automatic')
+    expect(migrated).not.toHaveProperty('terminalRenderMode')
+    expect(migrated).not.toHaveProperty('gpuRendererForClaudeTerminals')
+  })
+
+  it.each([
     ['default', 'tokyo-night'],
     ['dusk', 'rose-pine'],
     ['lime', 'catppuccin'],
@@ -61,6 +162,8 @@ describe('migrateSettings', () => {
       uiStyle: 'terminal',
       terminalStyleOptions: { colorPreset: 'blue', fontFamily: 'fira-code' },
       reflowSafeScrollback: true,
+      terminalRenderMode: 'balanced',
+      gpuRendererForClaudeTerminals: false,
     })
 
     expect(first).not.toHaveProperty('enableThinkingSyntaxHighlight')
@@ -69,6 +172,8 @@ describe('migrateSettings', () => {
     expect(first).not.toHaveProperty('uiStyle')
     expect(first).not.toHaveProperty('terminalStyleOptions')
     expect(first).not.toHaveProperty('reflowSafeScrollback')
+    expect(first).not.toHaveProperty('terminalRenderMode')
+    expect(first).not.toHaveProperty('gpuRendererForClaudeTerminals')
     expect(first.settingsSchemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION)
     expect(migrateSettings(first)).toEqual(first)
   })

--- a/src/main/settings/__tests__/settings-store.spec.ts
+++ b/src/main/settings/__tests__/settings-store.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { SCROLLBACK_DEFAULT, SCROLLBACK_MAX, SCROLLBACK_MIN } from '@shared/constants'
+import { DEFAULT_SETTINGS, SCROLLBACK_DEFAULT, SCROLLBACK_MAX, SCROLLBACK_MIN } from '@shared/constants'
 import { SettingsStore } from '../settings-store'
 import { SETTINGS_MIGRATION_FIXTURES } from './settings-migration-fixtures'
 
@@ -14,6 +14,45 @@ describe('SettingsStore', () => {
 
     expect(updated.terminalFontFamily).toBe('system')
     expect(store.getSettings().terminalFontFamily).toBe('system')
+  })
+
+  it('creates a canonical schema-v2 renderer profile by default', () => {
+    const settings = new SettingsStore().getSettings()
+
+    expect(settings.settingsSchemaVersion).toBe(2)
+    expect(settings.terminalRendererPolicy).toBe('automatic')
+    expect(settings).not.toHaveProperty('terminalRenderMode')
+    expect(settings).not.toHaveProperty('gpuRendererForClaudeTerminals')
+    expect(DEFAULT_SETTINGS.settingsSchemaVersion).toBe(2)
+  })
+
+  it.each(['automatic', 'prefer-gpu', 'safe-dom'] as const)(
+    'round-trips canonical renderer policy %s',
+    (terminalRendererPolicy) => {
+      const store = new SettingsStore()
+
+      expect(store.setSettings({ terminalRendererPolicy }).terminalRendererPolicy)
+        .toBe(terminalRendererPolicy)
+      expect(store.getSettings().terminalRendererPolicy).toBe(terminalRendererPolicy)
+    },
+  )
+
+  it('preserves the current renderer policy across an unrelated partial update', () => {
+    const store = new SettingsStore()
+    store.setSettings({ terminalRendererPolicy: 'prefer-gpu' })
+
+    const updated = store.setSettings({ colorTheme: 'dracula' })
+
+    expect(updated.terminalRendererPolicy).toBe('prefer-gpu')
+  })
+
+  it('uses the current renderer policy when a partial update contains an invalid value', () => {
+    const store = new SettingsStore()
+    store.setSettings({ terminalRendererPolicy: 'safe-dom' })
+
+    const updated = store.setSettings({ terminalRendererPolicy: 'invalid' as never })
+
+    expect(updated.terminalRendererPolicy).toBe('safe-dom')
   })
 
   it.each(['tokyo-night', 'catppuccin', 'dracula', 'rose-pine', 'pro-dark'] as const)(
@@ -67,13 +106,14 @@ describe('SettingsStore', () => {
     expect(updated.terminalFontFamily).toBe('jetbrains-mono')
   })
 
-  it('persists the Claude GPU renderer override flag', () => {
+  it('migrates the legacy Claude GPU override without persisting retired keys', () => {
     const store = new SettingsStore()
 
     const updated = store.setSettings({ gpuRendererForClaudeTerminals: true } as never)
 
-    expect((updated as { gpuRendererForClaudeTerminals?: boolean }).gpuRendererForClaudeTerminals).toBe(true)
-    expect((store.getSettings() as { gpuRendererForClaudeTerminals?: boolean }).gpuRendererForClaudeTerminals).toBe(true)
+    expect(updated.terminalRendererPolicy).toBe('prefer-gpu')
+    expect(updated).not.toHaveProperty('gpuRendererForClaudeTerminals')
+    expect(store.getSettings()).not.toHaveProperty('gpuRendererForClaudeTerminals')
   })
 
   it('persists a valid scrollbackLines value within range', () => {
@@ -143,7 +183,7 @@ describe('SettingsStore', () => {
 
     expect(recovered.enableContextWindowAdvanced).toBe(true)
     expect(recovered.terminalEngine).toBe('xterm')
-    expect(recovered.terminalRenderMode).toBe('balanced')
+    expect(recovered.terminalRendererPolicy).toBe('automatic')
     expect(recovered.terminalLimit).toEqual({ preset: 9 })
   })
 
@@ -169,6 +209,10 @@ describe('SettingsStore', () => {
 
       expect(updated).toMatchObject(preserved)
       expect(store.getSettings()).toMatchObject(preserved)
+      for (const legacyKey of SETTINGS_MIGRATION_FIXTURES.find(fixture => fixture.payload === payload)?.legacyKeys ?? []) {
+        expect(updated).not.toHaveProperty(legacyKey)
+        expect(store.getSettings()).not.toHaveProperty(legacyKey)
+      }
     }
   )
 })

--- a/src/main/settings/settings-migrations.ts
+++ b/src/main/settings/settings-migrations.ts
@@ -1,7 +1,13 @@
-import type { AppSettings, ColorTheme, ShellInfo, WindowsShell } from '@shared/types'
+import type {
+  AppSettings,
+  ColorTheme,
+  ShellInfo,
+  TerminalRendererPolicy,
+  WindowsShell,
+} from '@shared/types'
 import { THEMES } from '@shared/constants'
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 1
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 2
 
 const CURRENT_THEME_IDS = new Set(THEMES.map(theme => theme.id))
 
@@ -31,7 +37,44 @@ const RETIRED_KEYS = [
   'terminalStyleOptions',
   'reflowSafeScrollback',
   'windowsShell',
+  'terminalRenderMode',
+  'gpuRendererForClaudeTerminals',
 ] as const
+
+const TERMINAL_RENDERER_POLICIES: ReadonlySet<TerminalRendererPolicy> = new Set([
+  'automatic',
+  'prefer-gpu',
+  'safe-dom',
+])
+
+function isTerminalRendererPolicy(value: unknown): value is TerminalRendererPolicy {
+  return typeof value === 'string'
+    && TERMINAL_RENDERER_POLICIES.has(value as TerminalRendererPolicy)
+}
+
+function migrateTerminalRendererPolicy(
+  raw: Record<string, unknown>,
+): TerminalRendererPolicy | undefined {
+  const hasOwn = (key: string): boolean => Object.prototype.hasOwnProperty.call(raw, key)
+  if (hasOwn('terminalRendererPolicy') && isTerminalRendererPolicy(raw.terminalRendererPolicy)) {
+    return raw.terminalRendererPolicy
+  }
+
+  const schemaVersion = hasOwn('settingsSchemaVersion')
+    ? raw.settingsSchemaVersion
+    : undefined
+  if (typeof schemaVersion === 'number' && schemaVersion >= 2) return undefined
+
+  const legacyMode = hasOwn('terminalRenderMode') ? raw.terminalRenderMode : undefined
+  const legacyGpuFlag = hasOwn('gpuRendererForClaudeTerminals')
+    ? raw.gpuRendererForClaudeTerminals
+    : undefined
+  if (legacyMode === 'performance') return 'safe-dom'
+  if (legacyGpuFlag === true) return 'prefer-gpu'
+  if (legacyMode === 'quality') return 'prefer-gpu'
+  if (legacyMode === 'balanced') return 'automatic'
+  return undefined
+}
 
 function migrateWindowsShell(shell: unknown): ShellInfo | undefined {
   if (!shell || typeof shell !== 'object' || !('type' in shell)) return undefined
@@ -67,6 +110,11 @@ function migrateWindowsShell(shell: unknown): ShellInfo | undefined {
 export function migrateSettings(raw: Record<string, unknown>): Record<string, unknown> {
   const migrated = structuredClone(raw)
   const legacyStyle = migrated.terminalStyleOptions
+  const terminalRendererPolicy = migrateTerminalRendererPolicy(raw)
+
+  if (terminalRendererPolicy) {
+    migrated.terminalRendererPolicy = terminalRendererPolicy
+  }
 
   if (typeof migrated.colorTheme === 'string') {
     if (!CURRENT_THEME_IDS.has(migrated.colorTheme as ColorTheme)) {

--- a/src/main/settings/settings-store.ts
+++ b/src/main/settings/settings-store.ts
@@ -1,6 +1,6 @@
 import Store from 'electron-store'
 import { app } from 'electron'
-import type { AppSettings, ThemeMode, TerminalRenderMode, TerminalFontId, AppFontId, ShellInfo, TerminalEngine } from '@shared/types'
+import type { AppSettings, ThemeMode, TerminalRendererPolicy, TerminalFontId, AppFontId, ShellInfo, TerminalEngine } from '@shared/types'
 import { DEFAULT_SETTINGS, SCROLLBACK_MIN, SCROLLBACK_MAX, THEMES } from '@shared/constants'
 import { getNativeTerminalCapability, resolveTerminalEngine } from '../terminal/native-terminal-capability'
 import { CURRENT_SETTINGS_SCHEMA_VERSION, migrateSettings } from './settings-migrations'
@@ -38,7 +38,7 @@ interface SettingsStoreOptions {
 // Allowed values for enum-like settings
 const VALID_THEME_MODES: ThemeMode[] = ['light', 'dark', 'system']
 const VALID_COLOR_THEMES = new Set(THEMES.map(theme => theme.id))
-const VALID_RENDER_MODES: TerminalRenderMode[] = ['performance', 'balanced', 'quality']
+const VALID_RENDERER_POLICIES: TerminalRendererPolicy[] = ['automatic', 'prefer-gpu', 'safe-dom']
 const VALID_TERMINAL_PRESETS = [2, 4, 9, 'custom'] as const
 const VALID_TERMINAL_FONT_IDS: TerminalFontId[] = ['system', 'jetbrains-mono', 'source-code-pro', 'fira-code', 'vt323', 'ibm-plex-mono', 'space-mono']
 const VALID_APP_FONT_IDS: AppFontId[] = ['system', 'inter', 'geist', 'plus-jakarta-sans', 'roboto', 'ubuntu', 'segoe-ui']
@@ -76,18 +76,12 @@ export function validateSettings(settings: Partial<AppSettings>, defaults: AppSe
     )
   }
 
-  // Validate terminalRenderMode
-  if (settings.terminalRenderMode !== undefined) {
-    validated.terminalRenderMode = VALID_RENDER_MODES.includes(settings.terminalRenderMode)
-      ? settings.terminalRenderMode
-      : defaults.terminalRenderMode
-  }
-
-  if (settings.gpuRendererForClaudeTerminals !== undefined) {
-    validated.gpuRendererForClaudeTerminals =
-      typeof settings.gpuRendererForClaudeTerminals === 'boolean'
-        ? settings.gpuRendererForClaudeTerminals
-        : defaults.gpuRendererForClaudeTerminals
+  if (settings.terminalRendererPolicy !== undefined) {
+    validated.terminalRendererPolicy = VALID_RENDERER_POLICIES.includes(
+      settings.terminalRendererPolicy,
+    )
+      ? settings.terminalRendererPolicy
+      : defaults.terminalRendererPolicy
   }
 
   // Validate scrollbackLines (clamp to allowed range; fall back to default on non-numeric input)
@@ -205,13 +199,10 @@ export class SettingsStore {
     const transaction = this.store.get('settingsMigration')
     const recovered = recoverSettingsMigrationOnLaunch(raw, transaction)
     if (transaction) {
-      const recoveredSettings = recovered.restoredBackup
-        ? this.completeSettingsProfile(recovered.settings)
-        : recovered.settings as unknown as AppSettings
-      this.store.set('settings', recoveredSettings)
-      this.store.set('settingsMigration', recovered.transaction)
-      if (recovered.restoredBackup) return
-      if (recovered.transaction?.phase === 'next-launch-expiry-pending') return
+      if (!recovered.restoredBackup) {
+        this.store.set('settingsMigration', recovered.transaction)
+        if (recovered.transaction?.phase === 'next-launch-expiry-pending') return
+      }
     }
 
     const migrated = {
@@ -227,31 +218,32 @@ export class SettingsStore {
     candidateSettings.terminalEngine = resolveTerminalEngine(candidateSettings.terminalEngine)
     if (JSON.stringify(recovered.settings) === JSON.stringify(candidateSettings)) return
 
-    const backup = structuredClone(
-      this.completeSettingsProfile(recovered.settings),
-    ) as unknown as Record<string, unknown>
+    const backup = structuredClone(recovered.settings)
     const candidate = structuredClone(candidateSettings) as unknown as Record<string, unknown>
-    this.store.set('settingsMigration', {
-      phase: 'backup-written',
-      backup,
-      candidate,
-    })
-    this.store.set('settingsMigration', beginSettingsMigration(backup, candidate))
-    this.store.set('settings', candidateSettings)
+    try {
+      this.store.set('settingsMigration', {
+        phase: 'backup-written',
+        backup,
+        candidate,
+      })
+      this.store.set('settingsMigration', beginSettingsMigration(backup, candidate))
+      this.store.set('settings', candidateSettings)
 
-    const persistedCandidate = this.store.get('settings')
-    const readValidated = {
-      ...this.channelDefaults,
-      ...validateSettings(persistedCandidate ?? {}, this.channelDefaults),
-      settingsSchemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
-    } as AppSettings
-    readValidated.terminalEngine = resolveTerminalEngine(readValidated.terminalEngine)
-    if (
-      JSON.stringify(persistedCandidate) !== JSON.stringify(candidateSettings) ||
-      JSON.stringify(readValidated) !== JSON.stringify(candidateSettings)
-    ) {
-      this.store.set('settings', backup as unknown as AppSettings)
-      this.store.set('settingsMigration', null)
+      const persistedCandidate = this.store.get('settings')
+      const readValidated = {
+        ...this.channelDefaults,
+        ...validateSettings(persistedCandidate ?? {}, this.channelDefaults),
+        settingsSchemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+      } as AppSettings
+      readValidated.terminalEngine = resolveTerminalEngine(readValidated.terminalEngine)
+      if (
+        JSON.stringify(persistedCandidate) !== JSON.stringify(candidateSettings) ||
+        JSON.stringify(readValidated) !== JSON.stringify(candidateSettings)
+      ) {
+        throw new Error('candidate verification mismatch')
+      }
+    } catch {
+      throw new Error('Settings migration failed; restart MultiClaude to retry.')
     }
   }
 

--- a/src/renderer/__tests__/auto-resync.spec.ts
+++ b/src/renderer/__tests__/auto-resync.spec.ts
@@ -160,6 +160,40 @@ describe('terminal-lifecycle-dispatcher', () => {
     expect(cbAlive).toHaveBeenCalledTimes(1)
     expect(cbDead).not.toHaveBeenCalled()
   })
+
+  it('keeps a same-ID replacement when the old session unsubscribes late', () => {
+    attachTerminalLifecycleDispatcher(mockOnSystemResumed)
+    const oldToken = Symbol('old')
+    const newToken = Symbol('new')
+    const oldCallback = vi.fn()
+    const newCallback = vi.fn()
+    subscribeToSystemResume('term-1', oldToken, oldCallback)
+    subscribeToSystemResume('term-1', newToken, newCallback)
+
+    unsubscribeFromSystemResume('term-1', oldToken)
+    triggerSystemResumed()
+
+    expect(oldCallback).not.toHaveBeenCalled()
+    expect(newCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues fan-out and logs fixed copy when one handler throws', () => {
+    attachTerminalLifecycleDispatcher(mockOnSystemResumed)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const healthy = vi.fn()
+    subscribeToSystemResume('term-bad', Symbol('bad'), () => {
+      throw new Error('/private/renderer failure')
+    })
+    subscribeToSystemResume('term-good', Symbol('good'), healthy)
+
+    triggerSystemResumed()
+
+    expect(healthy).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[lifecycle-dispatcher] System-resume handler failed.',
+    )
+    expect(consoleError).not.toHaveBeenCalledWith(expect.anything(), expect.anything())
+  })
 })
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/renderer/components/settings/diagnostics-settings.spec.tsx
+++ b/src/renderer/components/settings/diagnostics-settings.spec.tsx
@@ -98,6 +98,7 @@ describe('DiagnosticsSettings renderer policy', () => {
     expect(document.body.textContent).not.toContain('main-orphan')
     expect(document.body.textContent).not.toContain('renderer-orphan')
     expect(document.body.textContent).not.toContain('SECRET')
+    expect(screen.getByTestId('terminal-stream-diagnostics').getAttribute('data-renderer-registry-count')).toBe('2')
   })
 
   it('keeps local renderer status visible when the first main request fails', async () => {
@@ -176,6 +177,7 @@ describe('DiagnosticsSettings renderer policy', () => {
 
     act(() => { useAppStore.setState({ terminals: [] }) })
     await waitFor(() => expect(screen.queryByText('term-safe-id')).toBeNull())
+    expect(screen.getByTestId('terminal-stream-diagnostics').getAttribute('data-renderer-registry-count')).toBe('1')
     view.unmount()
   })
 })

--- a/src/renderer/components/settings/diagnostics-settings.spec.tsx
+++ b/src/renderer/components/settings/diagnostics-settings.spec.tsx
@@ -1,23 +1,47 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { DEFAULT_NOTIFICATION_SETTINGS } from '@shared/constants'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { DEFAULT_NOTIFICATION_SETTINGS, DEFAULT_SETTINGS } from '@shared/constants'
+import { useAppStore } from '../../stores/app-store'
 import { useNotificationStore } from '../../stores/notification-store'
+import { useSettingsStore } from '../../stores/settings-store'
+import {
+  claimTerminalRendererSession,
+  registerTerminalRendererRetry,
+  resetTerminalRendererStatusStoreForTests,
+  setTerminalRendererStatus,
+} from '../../stores/terminal-renderer-status-store'
 import { DiagnosticsSettings } from './diagnostics-settings'
 
 const getDiagnostics = vi.fn()
+const token = Symbol('diagnostics-session')
 
-beforeEach(() => {
-  getDiagnostics.mockReset().mockResolvedValue([{
-    terminalId: 'term-safe-id',
-    provider: 'codex',
-    engine: 'xterm',
-    backend: 'xterm-headless',
+function liveTerminal(id = 'term-safe-id', agentType: 'generic' | 'claude' | 'codex' = 'generic') {
+  return {
+    id,
+    title: 'SECRET terminal title',
+    cwd: '/SECRET/private/path',
+    isClaudeMode: false,
+    agentType,
+    createdAt: new Date(),
+  }
+}
+
+function mainDiagnostic(terminalId = 'term-safe-id', fallbackReason: string | null = null) {
+  return {
+    terminalId,
+    provider: 'codex' as const,
+    engine: 'xterm' as const,
+    backend: 'xterm-headless' as const,
     backendAvailable: true,
     lastSequence: 41,
     watermark: 40,
-    fallbackReason: null,
-  }])
+    fallbackReason,
+  }
+}
+
+beforeEach(() => {
+  getDiagnostics.mockReset().mockResolvedValue([mainDiagnostic()])
   Object.defineProperty(window, 'electron', {
     writable: true,
     configurable: true,
@@ -29,25 +53,129 @@ beforeEach(() => {
     hasUnsavedChanges: false,
     isLoading: false,
   })
+  useSettingsStore.setState({
+    settings: DEFAULT_SETTINGS,
+    savedSettings: DEFAULT_SETTINGS,
+    pendingSettings: DEFAULT_SETTINGS,
+    hasUnsavedChanges: false,
+  })
+  useAppStore.setState({ terminals: [liveTerminal()] })
+  resetTerminalRendererStatusStoreForTests()
+  claimTerminalRendererSession('term-safe-id', token)
+  setTerminalRendererStatus('term-safe-id', token, {
+    effective: 'webgl',
+    fallbackReason: null,
+  })
 })
 
-describe('DiagnosticsSettings terminal metadata', () => {
-  it('renders provider, engine/backend, sequence/watermark, and fallback without transcript content', async () => {
+describe('DiagnosticsSettings renderer policy', () => {
+  it('renders an accessible canonical policy group with exact copy and updates pending state', async () => {
     render(<DiagnosticsSettings />)
 
-    expect(await screen.findByText('codex')).toBeTruthy()
-    expect(screen.getByText('xterm / xterm-headless (available)')).toBeTruthy()
-    expect(screen.getByText('41 / 40')).toBeTruthy()
-    expect(screen.getByText('none')).toBeTruthy()
-    expect(document.body.textContent).not.toContain('transcript')
+    expect(screen.getByRole('radiogroup', { name: 'Terminal renderer policy' })).toBeTruthy()
+    expect((screen.getByRole('radio', { name: 'Automatic (Recommended)' }) as HTMLInputElement).checked).toBe(true)
+    expect(screen.getByText('WebGL for regular shells; safer non-WebGL rendering for Claude and Codex.')).toBeTruthy()
+    expect(screen.getByText('Attempts WebGL for all terminals and falls back automatically.')).toBeTruthy()
+    expect(screen.getByText('Disables WebGL for maximum compatibility.')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
-    await waitFor(() => expect(getDiagnostics).toHaveBeenCalledTimes(2))
+    fireEvent.click(screen.getByRole('radio', { name: 'Compatibility' }))
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('safe-dom')
+    expect(useSettingsStore.getState().hasUnsavedChanges).toBe(true)
+    await screen.findByText('WebGL')
   })
 
-  it('fails closed when runtime diagnostics are unavailable', async () => {
-    getDiagnostics.mockRejectedValueOnce(new Error('unavailable'))
+  it('joins main and renderer state from live terminal IDs and omits orphans and private labels', async () => {
+    getDiagnostics.mockResolvedValue([
+      mainDiagnostic(),
+      mainDiagnostic('main-orphan'),
+    ])
+    claimTerminalRendererSession('renderer-orphan', Symbol('orphan'))
     render(<DiagnosticsSettings />)
+
+    expect(await screen.findByText('xterm / xterm-headless (available)')).toBeTruthy()
+    expect(screen.getByText('term-safe-id')).toBeTruthy()
+    expect(screen.getByText('WebGL')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('main-orphan')
+    expect(document.body.textContent).not.toContain('renderer-orphan')
+    expect(document.body.textContent).not.toContain('SECRET')
+  })
+
+  it('keeps local renderer status visible when the first main request fails', async () => {
+    getDiagnostics.mockRejectedValueOnce(new Error('SECRET device failure'))
+    setTerminalRendererStatus('term-safe-id', token, {
+      effective: 'dom',
+      fallbackReason: 'automatic-agent-safe',
+    })
+    render(<DiagnosticsSettings />)
+
     expect(await screen.findByText('Terminal diagnostics are unavailable.')).toBeTruthy()
+    expect(screen.getByText('DOM')).toBeTruthy()
+    expect(screen.getByText('Automatic uses safer rendering for this agent.')).toBeTruthy()
+    expect(screen.getByText('Backend metadata unavailable')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('SECRET')
+  })
+
+  it('sanitizes unknown main fallback text and maps the known backend reason', async () => {
+    getDiagnostics.mockResolvedValue([
+      mainDiagnostic('term-safe-id', 'SECRET GPU and command text'),
+    ])
+    const view = render(<DiagnosticsSettings />)
+    expect(await screen.findByText('Backend unavailable')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('SECRET')
+
+    getDiagnostics.mockResolvedValue([
+      mainDiagnostic('term-safe-id', 'Canonical xterm headless mirror unavailable.'),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(screen.getByText('Canonical terminal mirror unavailable.')).toBeTruthy())
+    view.unmount()
+  })
+
+  it('retries only the selected recoverable terminal while desired renderer is WebGL', async () => {
+    const retry = vi.fn(() => true)
+    setTerminalRendererStatus('term-safe-id', token, {
+      effective: 'dom',
+      fallbackReason: 'webgl-context-lost',
+    })
+    registerTerminalRendererRetry('term-safe-id', token, retry)
+    render(<DiagnosticsSettings />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry GPU for term-safe-id' }))
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('automatic')
+  })
+
+  it('hides Retry GPU under Compatibility and for non-recoverable reasons', async () => {
+    useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'safe-dom' },
+    })
+    setTerminalRendererStatus('term-safe-id', token, {
+      effective: 'dom',
+      fallbackReason: 'webgl-load-failed',
+    })
+    const view = render(<DiagnosticsSettings />)
+    await screen.findByText('DOM')
+    expect(screen.queryByRole('button', { name: /Retry GPU/ })).toBeNull()
+
+    view.unmount()
+    useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'automatic' },
+    })
+    setTerminalRendererStatus('term-safe-id', token, {
+      effective: 'dom',
+      fallbackReason: 'automatic-agent-safe',
+    })
+    render(<DiagnosticsSettings />)
+    await screen.findByText('DOM')
+    expect(screen.queryByRole('button', { name: /Retry GPU/ })).toBeNull()
+  })
+
+  it('removes a diagnostics row when its live terminal closes', async () => {
+    const view = render(<DiagnosticsSettings />)
+    expect(await screen.findByText('term-safe-id')).toBeTruthy()
+
+    act(() => { useAppStore.setState({ terminals: [] }) })
+    await waitFor(() => expect(screen.queryByText('term-safe-id')).toBeNull())
+    view.unmount()
   })
 })

--- a/src/renderer/components/settings/diagnostics-settings.tsx
+++ b/src/renderer/components/settings/diagnostics-settings.tsx
@@ -1,31 +1,216 @@
-import { useEffect, useState } from 'react'
-import type { OutputMode, TerminalPlatformDiagnostic } from '@shared/types'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  OutputMode,
+  TerminalPlatformDiagnostic,
+  TerminalRendererPolicy,
+} from '@shared/types'
+import { useAppStore } from '../../stores/app-store'
 import { useNotificationStore } from '../../stores/notification-store'
+import { useSettingsStore } from '../../stores/settings-store'
+import {
+  retryTerminalRenderer,
+  useTerminalRendererStatusStore,
+  type TerminalRendererStatus,
+} from '../../stores/terminal-renderer-status-store'
+import {
+  resolveTerminalRenderer,
+  type RendererFallbackReason,
+} from '../../utils/terminal-renderer-policy'
 import { SettingsTitle } from './settings-typography'
 
+const RENDERER_POLICIES: ReadonlyArray<{
+  value: TerminalRendererPolicy
+  label: string
+  description: string
+}> = [
+  {
+    value: 'automatic',
+    label: 'Automatic (Recommended)',
+    description: 'WebGL for regular shells; safer non-WebGL rendering for Claude and Codex.',
+  },
+  {
+    value: 'prefer-gpu',
+    label: 'Prefer GPU',
+    description: 'Attempts WebGL for all terminals and falls back automatically.',
+  },
+  {
+    value: 'safe-dom',
+    label: 'Compatibility',
+    description: 'Disables WebGL for maximum compatibility.',
+  },
+]
+
+const RENDERER_REASON_COPY: Record<RendererFallbackReason, string> = {
+  'automatic-agent-safe': 'Automatic uses safer rendering for this agent.',
+  'policy-safe': 'Compatibility disables WebGL.',
+  'webgl-unavailable': 'WebGL is unavailable in this environment.',
+  'webgl-load-failed': 'WebGL could not start.',
+  'webgl-context-lost': 'WebGL context lost.',
+}
+
+const RECOVERABLE_REASONS: ReadonlySet<RendererFallbackReason> = new Set([
+  'webgl-load-failed',
+  'webgl-context-lost',
+])
+
+function mainFallbackCopy(reason: string | null): string {
+  if (reason === null) return 'none'
+  if (reason === 'Canonical xterm headless mirror unavailable.') {
+    return 'Canonical terminal mirror unavailable.'
+  }
+  return 'Backend unavailable'
+}
+
+interface DiagnosticRowProps {
+  terminalId: string
+  terminalAgentType: Parameters<typeof resolveTerminalRenderer>[0]['agentType']
+  terminalIsClaudeMode: boolean
+  policy: TerminalRendererPolicy
+  main?: TerminalPlatformDiagnostic
+  renderer?: TerminalRendererStatus
+}
+
+function DiagnosticRow({
+  terminalId,
+  terminalAgentType,
+  terminalIsClaudeMode,
+  policy,
+  main,
+  renderer,
+}: DiagnosticRowProps) {
+  const desired = resolveTerminalRenderer({
+    policy,
+    agentType: terminalAgentType,
+    isClaudeMode: terminalIsClaudeMode,
+  }).desired
+  const canRetry = renderer?.fallbackReason !== null
+    && renderer?.fallbackReason !== undefined
+    && RECOVERABLE_REASONS.has(renderer.fallbackReason)
+    && desired === 'webgl'
+
+  return (
+    <div
+      data-renderer-terminal-id={terminalId}
+      data-renderer-effective={renderer?.effective ?? 'unavailable'}
+      data-renderer-fallback={renderer?.fallbackReason ?? 'none'}
+      className="rounded-lg border border-[var(--mc-border)] p-3 text-sm"
+    >
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1">
+        <dt className="text-[var(--mc-text-muted)]">Terminal</dt>
+        <dd className="truncate">{terminalId}</dd>
+        <dt className="text-[var(--mc-text-muted)]">Renderer</dt>
+        <dd>{renderer ? (renderer.effective === 'webgl' ? 'WebGL' : 'DOM') : 'Unavailable'}</dd>
+        <dt className="text-[var(--mc-text-muted)]">Renderer fallback</dt>
+        <dd>
+          {renderer
+            ? (renderer.fallbackReason ? RENDERER_REASON_COPY[renderer.fallbackReason] : 'none')
+            : 'Renderer status unavailable.'}
+        </dd>
+        {main ? (
+          <>
+            <dt className="text-[var(--mc-text-muted)]">Provider</dt><dd>{main.provider ?? 'unmanaged'}</dd>
+            <dt className="text-[var(--mc-text-muted)]">Engine / backend</dt>
+            <dd>{main.engine} / {main.backend} ({main.backendAvailable ? 'available' : 'unavailable'})</dd>
+            <dt className="text-[var(--mc-text-muted)]">Sequence / watermark</dt>
+            <dd>{main.lastSequence} / {main.watermark}</dd>
+            <dt className="text-[var(--mc-text-muted)]">Backend fallback</dt>
+            <dd>{mainFallbackCopy(main.fallbackReason)}</dd>
+          </>
+        ) : (
+          <>
+            <dt className="text-[var(--mc-text-muted)]">Terminal stream</dt>
+            <dd>Backend metadata unavailable</dd>
+          </>
+        )}
+      </dl>
+      {canRetry && (
+        <button
+          type="button"
+          aria-label={`Retry GPU for ${terminalId}`}
+          onClick={() => { retryTerminalRenderer(terminalId) }}
+          className="mt-3 text-sm border border-[var(--mc-border)] rounded px-3 py-2 text-[var(--mc-text-primary)]"
+        >
+          Retry GPU
+        </button>
+      )}
+    </div>
+  )
+}
+
 export function DiagnosticsSettings() {
-  const { pendingSettings, updateSettings } = useNotificationStore()
+  const { pendingSettings: notificationSettings, updateSettings } = useNotificationStore()
+  const rendererPolicy = useSettingsStore(state => state.pendingSettings.terminalRendererPolicy)
+  const setTerminalRendererPolicy = useSettingsStore(state => state.setTerminalRendererPolicy)
+  const terminals = useAppStore(state => state.terminals)
+  const rendererStatuses = useTerminalRendererStatusStore(state => state.statuses)
   const [terminalDiagnostics, setTerminalDiagnostics] = useState<TerminalPlatformDiagnostic[]>([])
   const [diagnosticError, setDiagnosticError] = useState<string | null>(null)
 
-  const refreshDiagnostics = async () => {
+  const refreshDiagnostics = useCallback(async () => {
     try {
       setTerminalDiagnostics(await window.electron.terminal.getDiagnostics())
       setDiagnosticError(null)
     } catch {
       setDiagnosticError('Terminal diagnostics are unavailable.')
     }
-  }
+  }, [])
 
   useEffect(() => {
     void refreshDiagnostics()
-  }, [])
+  }, [refreshDiagnostics])
+
+  const mainByTerminalId = useMemo(
+    () => new Map(terminalDiagnostics.map(diagnostic => [diagnostic.terminalId, diagnostic])),
+    [terminalDiagnostics],
+  )
 
   return (
     <div className="flex flex-col gap-8 pb-16 max-w-2xl">
       <SettingsTitle description="Advanced detection and troubleshooting controls">
         Diagnostics
       </SettingsTitle>
+
+      <div className="settings-card rounded-xl flex flex-col gap-3">
+        <div>
+          <p id="terminal-renderer-policy-label" className="text-base font-semibold text-[var(--mc-text-primary)]">
+            Terminal renderer policy
+          </p>
+          <p id="terminal-renderer-policy-help" className="text-sm text-[var(--mc-text-muted)] mt-0.5">
+            Choose how terminal panes attempt hardware-accelerated rendering.
+          </p>
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="terminal-renderer-policy-label"
+          aria-describedby="terminal-renderer-policy-help"
+          className="flex flex-col gap-2"
+        >
+          {RENDERER_POLICIES.map(option => (
+            <label key={option.value} className="flex items-start gap-3 rounded-lg border border-[var(--mc-border)] p-3">
+              <input
+                type="radio"
+                aria-label={option.label}
+                aria-describedby={`terminal-renderer-policy-${option.value}-description`}
+                name="terminal-renderer-policy"
+                value={option.value}
+                checked={rendererPolicy === option.value}
+                onChange={() => setTerminalRendererPolicy(option.value)}
+                className="mt-1 accent-[var(--mc-accent)]"
+              />
+              <span>
+                <span className="block font-medium text-[var(--mc-text-primary)]">{option.label}</span>
+                <span
+                  id={`terminal-renderer-policy-${option.value}-description`}
+                  className="block text-sm text-[var(--mc-text-muted)]"
+                >
+                  {option.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
       <div className="settings-card rounded-xl flex flex-col gap-3">
         <div>
           <p className="text-base font-semibold text-[var(--mc-text-primary)]">Detection Mode</p>
@@ -35,7 +220,7 @@ export function DiagnosticsSettings() {
         </div>
         <select
           aria-label="Detection Mode"
-          value={pendingSettings.outputMode}
+          value={notificationSettings.outputMode}
           onChange={(event) => updateSettings({ outputMode: event.target.value as OutputMode })}
           className="text-sm bg-[var(--mc-bg-primary)] border border-[var(--mc-border)] rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-[var(--mc-accent)] text-[var(--mc-text-primary)]"
         >
@@ -44,6 +229,7 @@ export function DiagnosticsSettings() {
           <option value="plain-text">Plain Text</option>
         </select>
       </div>
+
       <div className="settings-card rounded-xl flex flex-col gap-3">
         <div className="flex items-start justify-between gap-4">
           <div>
@@ -61,20 +247,19 @@ export function DiagnosticsSettings() {
           </button>
         </div>
         {diagnosticError && <p className="text-sm text-red-400">{diagnosticError}</p>}
-        {!diagnosticError && terminalDiagnostics.length === 0 && (
+        {terminals.length === 0 && (
           <p className="text-sm text-[var(--mc-text-muted)]">No active terminals.</p>
         )}
-        {terminalDiagnostics.map(diagnostic => (
-          <dl
-            key={diagnostic.terminalId}
-            className="grid grid-cols-2 gap-x-4 gap-y-1 rounded-lg border border-[var(--mc-border)] p-3 text-sm"
-          >
-            <dt className="text-[var(--mc-text-muted)]">Terminal</dt><dd className="truncate">{diagnostic.terminalId}</dd>
-            <dt className="text-[var(--mc-text-muted)]">Provider</dt><dd>{diagnostic.provider ?? 'unmanaged'}</dd>
-            <dt className="text-[var(--mc-text-muted)]">Engine / backend</dt><dd>{diagnostic.engine} / {diagnostic.backend} ({diagnostic.backendAvailable ? 'available' : 'unavailable'})</dd>
-            <dt className="text-[var(--mc-text-muted)]">Sequence / watermark</dt><dd>{diagnostic.lastSequence} / {diagnostic.watermark}</dd>
-            <dt className="text-[var(--mc-text-muted)]">Fallback</dt><dd>{diagnostic.fallbackReason ?? 'none'}</dd>
-          </dl>
+        {terminals.map(terminal => (
+          <DiagnosticRow
+            key={terminal.id}
+            terminalId={terminal.id}
+            terminalAgentType={terminal.agentType}
+            terminalIsClaudeMode={terminal.isClaudeMode}
+            policy={rendererPolicy}
+            main={mainByTerminalId.get(terminal.id)}
+            renderer={rendererStatuses[terminal.id]}
+          />
         ))}
       </div>
     </div>

--- a/src/renderer/components/settings/diagnostics-settings.tsx
+++ b/src/renderer/components/settings/diagnostics-settings.tsx
@@ -143,6 +143,7 @@ export function DiagnosticsSettings() {
   const setTerminalRendererPolicy = useSettingsStore(state => state.setTerminalRendererPolicy)
   const terminals = useAppStore(state => state.terminals)
   const rendererStatuses = useTerminalRendererStatusStore(state => state.statuses)
+  const rendererSessionCount = useTerminalRendererStatusStore(state => state.sessionCount)
   const [terminalDiagnostics, setTerminalDiagnostics] = useState<TerminalPlatformDiagnostic[]>([])
   const [diagnosticError, setDiagnosticError] = useState<string | null>(null)
 
@@ -230,7 +231,11 @@ export function DiagnosticsSettings() {
         </select>
       </div>
 
-      <div className="settings-card rounded-xl flex flex-col gap-3">
+      <div
+        data-testid="terminal-stream-diagnostics"
+        data-renderer-registry-count={rendererSessionCount}
+        className="settings-card rounded-xl flex flex-col gap-3"
+      >
         <div className="flex items-start justify-between gap-4">
           <div>
             <p className="text-base font-semibold text-[var(--mc-text-primary)]">Terminal Stream</p>

--- a/src/renderer/components/settings/settings-modal.spec.tsx
+++ b/src/renderer/components/settings/settings-modal.spec.tsx
@@ -1,10 +1,25 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import { SettingsModal } from './settings-modal'
+import { useSettingsStore } from '../../stores/settings-store'
 import { useNotificationStore } from '../../stores/notification-store'
-import { DEFAULT_NOTIFICATION_SETTINGS } from '@shared/constants'
+import { useToastStore } from '../../stores/toast-store'
+import { DEFAULT_NOTIFICATION_SETTINGS, DEFAULT_SETTINGS } from '@shared/constants'
 import type { MobileControlStatus } from '@main/notification/mobile-control-manager'
+
+const initialSettingsState = useSettingsStore.getState()
+const initialNotificationState = useNotificationStore.getState()
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
 
 interface MobileControlApi {
   getStatus: ReturnType<typeof vi.fn>
@@ -37,6 +52,10 @@ function makeMcStatus(overrides: Partial<MobileControlStatus> = {}): MobileContr
 }
 
 beforeEach(() => {
+  useSettingsStore.setState(initialSettingsState, true)
+  useNotificationStore.setState(initialNotificationState, true)
+  useToastStore.setState({ toasts: [] })
+
   const mobile: MobileControlApi = {
     getStatus: vi.fn().mockResolvedValue(makeMcStatus()),
     enable: vi.fn().mockResolvedValue(makeMcStatus()),
@@ -55,15 +74,30 @@ beforeEach(() => {
   Object.defineProperty(window, 'electron', {
     writable: true,
     configurable: true,
-    value: { mobileControl: mobile, notification }
+    value: {
+      mobileControl: mobile,
+      notification,
+      terminal: { getDiagnostics: vi.fn().mockResolvedValue([]) }
+    }
   })
   useNotificationStore.setState({
     savedSettings: DEFAULT_NOTIFICATION_SETTINGS,
     pendingSettings: DEFAULT_NOTIFICATION_SETTINGS,
     hasUnsavedChanges: false,
     isLoading: false,
-    remoteControlStatus: 'disconnected'
+    remoteControlStatus: 'disconnected',
+    loadSettings: vi.fn().mockResolvedValue(undefined)
   })
+  useSettingsStore.setState({
+    savedSettings: DEFAULT_SETTINGS,
+    pendingSettings: DEFAULT_SETTINGS,
+    settings: DEFAULT_SETTINGS,
+    hasUnsavedChanges: false
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('SettingsModal — settings ownership', () => {
@@ -126,6 +160,40 @@ describe('SettingsModal — settings ownership', () => {
     const diagnosticsTab = await screen.findByTestId('settings-tab-diagnostics')
     fireEvent.click(diagnosticsTab)
     expect(await screen.findByText('Detection Mode')).toBeTruthy()
+    expect(screen.getByRole('radiogroup', { name: 'Terminal renderer policy' })).toBeTruthy()
+  })
+
+  it('makes a renderer policy edit dirty and Cancel restores the saved policy', async () => {
+    const onClose = vi.fn()
+    render(<SettingsModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(await screen.findByTestId('settings-tab-diagnostics'))
+    await waitFor(() => expect(window.electron.terminal.getDiagnostics).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Compatibility' }))
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('safe-dom')
+    expect(screen.getByTestId('settings-save-button')).toHaveProperty('disabled', false)
+
+    fireEvent.click(screen.getByTestId('settings-cancel-button'))
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('automatic')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents renderer policy edits after Save submission until settlement', async () => {
+    const save = deferred()
+    useSettingsStore.setState({ saveSettings: vi.fn(() => save.promise) })
+    render(<SettingsModal isOpen={true} onClose={() => undefined} />)
+    fireEvent.click(await screen.findByTestId('settings-tab-diagnostics'))
+    await waitFor(() => expect(window.electron.terminal.getDiagnostics).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole('radio', { name: 'Prefer GPU' }))
+
+    fireEvent.click(screen.getByTestId('settings-save-button'))
+    const compatibility = screen.getByRole('radio', { name: 'Compatibility' })
+    expect(compatibility.matches(':disabled')).toBe(true)
+    compatibility.click()
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('prefer-gpu')
+
+    save.resolve()
+    await waitFor(() => expect(screen.getByTestId('settings-form')).toHaveProperty('disabled', false))
   })
 
   it('default active tab remains appearance', async () => {
@@ -153,5 +221,193 @@ describe('SettingsModal — settings ownership', () => {
     view.rerender(<SettingsModal isOpen={false} onClose={() => undefined} />)
     expect(document.activeElement).toBe(opener)
     opener.remove()
+  })
+
+  it.each([
+    ['Cancel', () => fireEvent.click(screen.getByTestId('settings-cancel-button'))],
+    ['X', () => fireEvent.click(screen.getByTestId('settings-close-button'))],
+    ['backdrop', () => fireEvent.click(screen.getByTestId('settings-backdrop'))],
+    ['Escape', () => fireEvent.keyDown(window, { key: 'Escape' })]
+  ])('rolls both pending snapshots back exactly once on %s', async (_name, dismiss) => {
+    const cancelSettings = vi.fn()
+    const cancelNotificationSettings = vi.fn()
+    let view: ReturnType<typeof render>
+    const onClose = vi.fn(() => {
+      view.rerender(<SettingsModal isOpen={false} onClose={onClose} />)
+    })
+    useSettingsStore.setState({ cancelSettings })
+    useNotificationStore.setState({ cancelSettings: cancelNotificationSettings })
+
+    view = render(<SettingsModal isOpen={true} onClose={onClose} />)
+    await screen.findByTestId('settings-modal')
+    dismiss()
+
+    expect(cancelSettings).toHaveBeenCalledTimes(1)
+    expect(cancelNotificationSettings).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls both pending snapshots back once before an external close paints', async () => {
+    const cancelSettings = vi.fn()
+    const cancelNotificationSettings = vi.fn()
+    const onClose = vi.fn()
+    useSettingsStore.setState({ cancelSettings })
+    useNotificationStore.setState({ cancelSettings: cancelNotificationSettings })
+    const view = render(<SettingsModal isOpen={true} onClose={onClose} />)
+    await screen.findByTestId('settings-modal')
+
+    view.rerender(<SettingsModal isOpen={false} onClose={onClose} />)
+
+    expect(screen.queryByTestId('settings-modal')).toBeNull()
+    expect(cancelSettings).toHaveBeenCalledTimes(1)
+    expect(cancelNotificationSettings).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('locks the whole form and every modal-owned dismissal while saving', async () => {
+    const save = deferred()
+    const saveSettings = vi.fn(() => save.promise)
+    const cancelSettings = vi.fn()
+    const cancelNotificationSettings = vi.fn()
+    const onClose = vi.fn()
+    useSettingsStore.setState({ hasUnsavedChanges: true, saveSettings, cancelSettings })
+    useNotificationStore.setState({ cancelSettings: cancelNotificationSettings })
+    render(<SettingsModal isOpen={true} onClose={onClose} />)
+
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+
+    expect(screen.getByTestId('settings-form')).toHaveProperty('disabled', true)
+    expect(screen.getByTestId('settings-close-button')).toHaveProperty('disabled', true)
+    expect(screen.getByTestId('settings-cancel-button')).toHaveProperty('disabled', true)
+    expect(screen.getByTestId('settings-tab-terminals').matches(':disabled')).toBe(true)
+
+    fireEvent.click(screen.getByTestId('settings-backdrop'))
+    fireEvent.click(screen.getByTestId('settings-close-button'))
+    fireEvent.click(screen.getByTestId('settings-cancel-button'))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(cancelSettings).not.toHaveBeenCalled()
+    expect(cancelNotificationSettings).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+
+    save.resolve()
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  it('closes exactly once after a successful save', async () => {
+    const onClose = vi.fn()
+    const saveSettings = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({ hasUnsavedChanges: true, saveSettings })
+    render(<SettingsModal isOpen={true} onClose={onClose} />)
+
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(saveSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays locked until every parallel save settles after one rejects', async () => {
+    const notificationSave = deferred()
+    const addToast = vi.spyOn(useToastStore.getState(), 'addToast')
+    useSettingsStore.setState({
+      hasUnsavedChanges: true,
+      saveSettings: vi.fn().mockRejectedValue(new Error('app save failed'))
+    })
+    useNotificationStore.setState({
+      hasUnsavedChanges: true,
+      saveSettings: vi.fn(() => notificationSave.promise)
+    })
+    render(<SettingsModal isOpen={true} onClose={() => undefined} />)
+
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+    await Promise.resolve()
+
+    expect(screen.getByTestId('settings-form')).toHaveProperty('disabled', true)
+    expect(addToast).not.toHaveBeenCalled()
+
+    notificationSave.resolve()
+    await waitFor(() => expect(screen.getByTestId('settings-form')).toHaveProperty('disabled', false))
+    expect(addToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps an external close authoritative when an in-flight save resolves', async () => {
+    const save = deferred()
+    const cancelSettings = vi.fn()
+    const cancelNotificationSettings = vi.fn()
+    const onClose = vi.fn()
+    useSettingsStore.setState({
+      hasUnsavedChanges: true,
+      saveSettings: vi.fn(() => save.promise),
+      cancelSettings
+    })
+    useNotificationStore.setState({ cancelSettings: cancelNotificationSettings })
+    const view = render(<SettingsModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+
+    view.rerender(<SettingsModal isOpen={false} onClose={onClose} />)
+    expect(cancelSettings).not.toHaveBeenCalled()
+    expect(cancelNotificationSettings).not.toHaveBeenCalled()
+
+    save.resolve()
+    await waitFor(() => expect(screen.queryByTestId('settings-modal')).toBeNull())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('reports one fixed-copy toast without reopening after an externally closed save rejects', async () => {
+    const save = deferred()
+    const cancelSettings = vi.fn()
+    const cancelNotificationSettings = vi.fn()
+    const onClose = vi.fn()
+    const addToast = vi.spyOn(useToastStore.getState(), 'addToast')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    useSettingsStore.setState({
+      hasUnsavedChanges: true,
+      saveSettings: vi.fn(() => save.promise),
+      cancelSettings
+    })
+    useNotificationStore.setState({ cancelSettings: cancelNotificationSettings })
+    const view = render(<SettingsModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+    view.rerender(<SettingsModal isOpen={false} onClose={onClose} />)
+
+    save.reject(new Error('private settings payload'))
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledTimes(1)
+      expect(addToast).toHaveBeenCalledWith('Failed to save settings. Please try again.', 'error')
+    })
+    expect(screen.queryByTestId('settings-modal')).toBeNull()
+    expect(cancelSettings).not.toHaveBeenCalled()
+    expect(cancelNotificationSettings).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('keeps app persistence truthful when notification saving fails afterward', async () => {
+    const persisted = { ...DEFAULT_SETTINGS, scrollbackLines: (DEFAULT_SETTINGS.scrollbackLines ?? 10_000) + 1 }
+    const onClose = vi.fn()
+    const saveSettings = vi.fn().mockImplementation(async () => {
+      useSettingsStore.setState({
+        savedSettings: persisted,
+        pendingSettings: persisted,
+        settings: persisted,
+        hasUnsavedChanges: false
+      })
+    })
+    const saveNotificationSettings = vi.fn().mockRejectedValue(new Error('provider secret'))
+    const addToast = vi.spyOn(useToastStore.getState(), 'addToast')
+    useSettingsStore.setState({ hasUnsavedChanges: true, saveSettings })
+    useNotificationStore.setState({
+      hasUnsavedChanges: true,
+      saveSettings: saveNotificationSettings
+    })
+    render(<SettingsModal isOpen={true} onClose={onClose} />)
+
+    fireEvent.click(await screen.findByTestId('settings-save-button'))
+
+    await waitFor(() => expect(addToast).toHaveBeenCalledTimes(1))
+    expect(useSettingsStore.getState().savedSettings).toEqual(persisted)
+    expect(useSettingsStore.getState().hasUnsavedChanges).toBe(false)
+    expect(useNotificationStore.getState().hasUnsavedChanges).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/settings/settings-modal.tsx
+++ b/src/renderer/components/settings/settings-modal.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { useNotificationStore, useSettingsStore } from '../../stores'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { useNotificationStore, useSettingsStore, useToastStore } from '../../stores'
 import { SettingsSidebar, type SettingsTab } from './settings-sidebar'
 import { ThemeSelector } from './theme-selector'
 import { TerminalSettings } from './terminal-settings'
@@ -17,6 +17,10 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>('appearance')
   const [isSaving, setIsSaving] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
+  const isSavingRef = useRef(false)
+  const isOpenRef = useRef(isOpen)
+  const wasOpenRef = useRef(isOpen)
+  const closeRollbackHandledRef = useRef(false)
   const { saveSettings, cancelSettings, hasUnsavedChanges } = useSettingsStore()
   const {
     saveSettings: saveNotificationSettings,
@@ -26,11 +30,35 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   } = useNotificationStore()
   const hasAnyUnsavedChanges = hasUnsavedChanges || hasUnsavedNotificationChanges
 
-  const handleCancel = useCallback(() => {
+  const rollbackPendingSettings = useCallback(() => {
     cancelSettings()
     cancelNotificationSettings()
+  }, [cancelNotificationSettings, cancelSettings])
+
+  const handleCancel = useCallback(() => {
+    if (isSavingRef.current) return
+    if (!closeRollbackHandledRef.current) {
+      closeRollbackHandledRef.current = true
+      rollbackPendingSettings()
+    }
     onClose()
-  }, [cancelNotificationSettings, cancelSettings, onClose])
+  }, [onClose, rollbackPendingSettings])
+
+  // App owns modal visibility, so a prop-driven close must discard previews too.
+  // Layout timing prevents a dirty preview from reaching the next paint.
+  useLayoutEffect(() => {
+    const wasOpen = wasOpenRef.current
+    isOpenRef.current = isOpen
+
+    if (isOpen && !wasOpen) {
+      closeRollbackHandledRef.current = false
+    } else if (wasOpen && !isOpen && !isSavingRef.current && !closeRollbackHandledRef.current) {
+      closeRollbackHandledRef.current = true
+      rollbackPendingSettings()
+    }
+
+    wasOpenRef.current = isOpen
+  }, [isOpen, rollbackPendingSettings])
 
   // Keep keyboard focus inside the modal and restore it on close.
   useEffect(() => {
@@ -43,7 +71,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     })
     const handleKeyboard = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        handleCancel()
+        if (!isSavingRef.current) handleCancel()
         return
       }
       if (event.key !== 'Tab' || !modalRef.current) return
@@ -78,6 +106,8 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   }, [isOpen, loadNotificationSettings])
 
   const handleSave = async () => {
+    if (isSavingRef.current) return
+    isSavingRef.current = true
     setIsSaving(true)
     try {
       const saveOperations: Promise<void>[] = []
@@ -90,11 +120,18 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         saveOperations.push(saveNotificationSettings())
       }
 
-      await Promise.all(saveOperations)
-      onClose()
-    } catch (err) {
-      console.error('Failed to save settings:', err)
+      const results = await Promise.allSettled(saveOperations)
+      if (results.some(({ status }) => status === 'rejected')) {
+        cancelNotificationSettings()
+        useToastStore.getState().addToast(
+          'Failed to save settings. Please try again.',
+          'error'
+        )
+      } else if (isOpenRef.current) {
+        onClose()
+      }
     } finally {
+      isSavingRef.current = false
       setIsSaving(false)
     }
   }
@@ -108,7 +145,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         data-testid="settings-backdrop"
         className="absolute inset-0"
         style={{ background: 'rgba(0, 0, 0, 0.75)', backdropFilter: 'blur(4px)' }}
-        onClick={handleCancel}
+        onClick={isSaving ? undefined : handleCancel}
         aria-hidden="true"
       />
 
@@ -118,6 +155,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         ref={modalRef}
         role="dialog"
         aria-modal="true"
+        aria-busy={isSaving}
         aria-labelledby="settings-dialog-title"
         className="relative bg-[var(--mc-bg-primary)] shadow-xl flex flex-col overflow-hidden rounded-xl"
         style={{ border: '1px solid color-mix(in srgb, var(--mc-accent) 30%, var(--mc-border))', width: 'calc(100% - 80px)', height: 'calc(100% - 60px)' }}
@@ -134,8 +172,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           <button
             data-testid="settings-close-button"
             onClick={handleCancel}
-            className="p-1.5 rounded transition-colors hover:bg-[var(--mc-bg-hover)]"
-            style={{ color: 'var(--mc-accent)', border: 'none', background: 'transparent', cursor: 'pointer' }}
+            disabled={isSaving}
+            className="p-1.5 rounded transition-colors hover:bg-[var(--mc-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ color: 'var(--mc-accent)', border: 'none', background: 'transparent', cursor: isSaving ? 'not-allowed' : 'pointer' }}
             title="Close"
             aria-label="Close Settings"
           >
@@ -143,42 +182,49 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           </button>
         </div>
 
-        {/* Body */}
-        <div className="flex flex-1 overflow-hidden">
-          <SettingsSidebar activeTab={activeTab} onTabChange={setActiveTab} />
-          <div className="flex-1 overflow-y-scroll text-left" style={{ padding: '32px 40px', scrollbarGutter: 'stable' }}>
-            {activeTab === 'appearance' && <ThemeSelector />}
-            {activeTab === 'terminals' && <TerminalSettings />}
-            {activeTab === 'notifications' && <NotificationSettings onNavigateToMobile={() => setActiveTab('agents-integrations')} />}
-            {activeTab === 'diagnostics' && <DiagnosticsSettings />}
-            {activeTab === 'agents-integrations' && <AgentsIntegrationsSettings />}
-            {activeTab === 'updates' && <UpdateSettings />}
+        <fieldset
+          data-testid="settings-form"
+          disabled={isSaving}
+          className="m-0 min-w-0 border-0 p-0 flex flex-1 flex-col overflow-hidden"
+        >
+          {/* Body */}
+          <div className="flex flex-1 overflow-hidden">
+            <SettingsSidebar activeTab={activeTab} onTabChange={setActiveTab} />
+            <div className="flex-1 overflow-y-scroll text-left" style={{ padding: '32px 40px', scrollbarGutter: 'stable' }}>
+              {activeTab === 'appearance' && <ThemeSelector />}
+              {activeTab === 'terminals' && <TerminalSettings />}
+              {activeTab === 'notifications' && <NotificationSettings onNavigateToMobile={() => setActiveTab('agents-integrations')} />}
+              {activeTab === 'diagnostics' && <DiagnosticsSettings />}
+              {activeTab === 'agents-integrations' && <AgentsIntegrationsSettings />}
+              {activeTab === 'updates' && <UpdateSettings />}
+            </div>
           </div>
-        </div>
 
-        {/* Footer */}
-        <div className="flex justify-end gap-4" style={{ padding: '25px 40px 25px 32px', borderTop: '1px solid color-mix(in srgb, var(--mc-accent) 20%, var(--mc-border))' }}>
-          <button
-            data-testid="settings-cancel-button"
-            onClick={handleCancel}
-            className="rounded-lg text-base font-semibold transition-all"
-            style={{ padding: '10px 28px', background: 'transparent', border: '2px solid var(--mc-text-secondary)', color: 'var(--mc-text-primary)' }}
-            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--mc-text-primary)'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--mc-bg-hover)' }}
-            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--mc-text-secondary)'; (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
-          >
-            Cancel
-          </button>
-          <button
-            data-testid="settings-save-button"
-            onClick={handleSave}
-            disabled={!hasAnyUnsavedChanges || isSaving}
-            className="rounded-lg text-base font-semibold flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-            style={{ padding: '10px 28px', background: 'var(--mc-accent)', color: 'var(--mc-bg-primary)', border: '2px solid var(--mc-accent)', boxShadow: '0 0 12px color-mix(in srgb, var(--mc-accent) 50%, transparent)' }}
-          >
-            <SaveIcon />
-            {isSaving ? 'Saving…' : 'Save Settings'}
-          </button>
-        </div>
+          {/* Footer */}
+          <div className="flex justify-end gap-4" style={{ padding: '25px 40px 25px 32px', borderTop: '1px solid color-mix(in srgb, var(--mc-accent) 20%, var(--mc-border))' }}>
+            <button
+              data-testid="settings-cancel-button"
+              onClick={handleCancel}
+              disabled={isSaving}
+              className="rounded-lg text-base font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{ padding: '10px 28px', background: 'transparent', border: '2px solid var(--mc-text-secondary)', color: 'var(--mc-text-primary)' }}
+              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--mc-text-primary)'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--mc-bg-hover)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--mc-text-secondary)'; (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
+            >
+              Cancel
+            </button>
+            <button
+              data-testid="settings-save-button"
+              onClick={handleSave}
+              disabled={!hasAnyUnsavedChanges || isSaving}
+              className="rounded-lg text-base font-semibold flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+              style={{ padding: '10px 28px', background: 'var(--mc-accent)', color: 'var(--mc-bg-primary)', border: '2px solid var(--mc-accent)', boxShadow: '0 0 12px color-mix(in srgb, var(--mc-accent) 50%, transparent)' }}
+            >
+              <SaveIcon />
+              {isSaving ? 'Saving…' : 'Save Settings'}
+            </button>
+          </div>
+        </fieldset>
       </div>
     </div>
   )

--- a/src/renderer/components/settings/terminal-settings.spec.tsx
+++ b/src/renderer/components/settings/terminal-settings.spec.tsx
@@ -4,7 +4,6 @@ import { DEFAULT_SETTINGS } from '@shared/constants'
 import type { AppSettings } from '@shared/types'
 import { useSettingsStore } from '../../stores'
 import {
-  getClaudeRendererControlState,
   getScrollbackRetentionNotice,
   shouldShowTerminalEngineSelector,
   TerminalSettings,
@@ -28,32 +27,15 @@ describe('TerminalSettings', () => {
     })
   })
 
-  it('shows an English helper badge and tooltip for the default Claude-safe renderer path', () => {
+  it('does not render the retired renderer mode card or Claude GPU control', () => {
     const html = renderToStaticMarkup(<TerminalSettings />)
 
-    expect(html).toContain('Claude-safe mode')
-    expect(html).toContain('Claude terminals stay on the safer canvas renderer.')
-    expect(html).toContain('Balanced and Quality still use WebGL for non-Claude terminals.')
-  })
-
-  it('updates the helper badge copy when the experimental Claude GPU override is enabled', () => {
-    expect(getClaudeRendererControlState('balanced', true)).toEqual({
-      badge: 'Claude follows mode',
-      description: 'Claude terminals use the selected render mode.',
-      tooltip: 'Performance keeps canvas everywhere. Balanced uses WebGL for the active terminal. Quality uses WebGL for all visible terminals.',
-      toggleDescription: 'Experimental. When enabled, Claude terminals use the selected GPU render mode.',
-      disabled: false
-    })
-  })
-
-  it('disables the Claude GPU override in Performance mode and explains why', () => {
-    expect(getClaudeRendererControlState('performance', true)).toEqual({
-      badge: 'GPU unavailable',
-      description: 'Performance mode disables GPU rendering for all terminals.',
-      tooltip: 'Switch to Balanced or Quality to choose whether Claude terminals can use GPU rendering.',
-      toggleDescription: 'Unavailable in Performance mode because GPU rendering is off for all terminals.',
-      disabled: true
-    })
+    expect(html).not.toContain('Rendering Mode')
+    expect(html).not.toContain('Use GPU renderer for Claude terminals')
+    expect(html).not.toContain('Performance')
+    expect(html).not.toContain('Balanced')
+    expect(html).not.toContain('Quality')
+    expect(html).not.toContain('canvas renderer')
   })
 
   it('renders the Advanced context-window controls with restart hint', () => {

--- a/src/renderer/components/settings/terminal-settings.tsx
+++ b/src/renderer/components/settings/terminal-settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useSettingsStore } from '../../stores'
 import { getShellKey, shellInfoToWindowsShell } from '../../utils'
-import type { ShellInfo, TerminalLimitPreset, TerminalRenderMode } from '@shared/types'
+import type { ShellInfo, TerminalLimitPreset } from '@shared/types'
 import {
   CANONICAL_SCROLLBACK_LINES,
   SCROLLBACK_DEFAULT,
@@ -36,65 +36,12 @@ const PRESET_OPTIONS: { value: TerminalLimitPreset; label: string }[] = [
   { value: 'custom', label: 'Custom' }
 ]
 
-// Icons for render modes
-const RENDER_MODE_ICONS: Record<string, string> = {
-  performance: '⚡',
-  balanced: '⚖️',
-  quality: '✨'
-}
-
-// Render mode definitions for UI display
-const RENDER_MODES: { id: TerminalRenderMode; name: string; description: string }[] = [
-  { id: 'performance', name: 'Performance', description: 'No WebGL, best for many terminals' },
-  { id: 'balanced', name: 'Balanced', description: 'WebGL only for active terminal' },
-  { id: 'quality', name: 'Quality', description: 'WebGL always, best visual quality' }
-]
-
-const CLAUDE_RENDERER_HELPER_COPY = {
-  performance: {
-    badge: 'GPU unavailable',
-    description: 'Performance mode disables GPU rendering for all terminals.',
-    tooltip: 'Switch to Balanced or Quality to choose whether Claude terminals can use GPU rendering.',
-    toggleDescription: 'Unavailable in Performance mode because GPU rendering is off for all terminals.',
-    disabled: true
-  },
-  safe: {
-    badge: 'Claude-safe mode',
-    description: 'Claude terminals stay on the safer canvas renderer.',
-    tooltip: 'Balanced and Quality still use WebGL for non-Claude terminals. Turn on the experimental switch below to let Claude terminals use GPU rendering too.',
-    toggleDescription: 'Experimental. When disabled, Claude terminals always use the safer canvas renderer.',
-    disabled: false
-  },
-  followMode: {
-    badge: 'Claude follows mode',
-    description: 'Claude terminals use the selected render mode.',
-    tooltip: 'Performance keeps canvas everywhere. Balanced uses WebGL for the active terminal. Quality uses WebGL for all visible terminals.',
-    toggleDescription: 'Experimental. When enabled, Claude terminals use the selected GPU render mode.',
-    disabled: false
-  }
-} as const
-
-export function getClaudeRendererControlState(
-  terminalRenderMode: TerminalRenderMode,
-  gpuRendererForClaudeTerminals: boolean | undefined
-) {
-  if (terminalRenderMode === 'performance') {
-    return CLAUDE_RENDERER_HELPER_COPY.performance
-  }
-
-  return gpuRendererForClaudeTerminals
-    ? CLAUDE_RENDERER_HELPER_COPY.followMode
-    : CLAUDE_RENDERER_HELPER_COPY.safe
-}
-
 export function TerminalSettings() {
   const {
     pendingSettings,
     wslInfo,
     setTerminalLimit,
-    setTerminalRenderMode,
     setTerminalEngine,
-    setGpuRendererForClaudeTerminals,
     setScrollbackLines,
     setEnableContextWindow,
     setEnableContextWindowAdvanced,
@@ -208,11 +155,6 @@ export function TerminalSettings() {
       }
     )
   )
-  const claudeRendererHelper = getClaudeRendererControlState(
-    pendingSettings.terminalRenderMode,
-    pendingSettings.gpuRendererForClaudeTerminals
-  )
-
   return (
     <div className="flex flex-col gap-6 pb-16 max-w-2xl">
       <SettingsTitle description="Configure terminal behavior and limits">
@@ -328,77 +270,6 @@ export function TerminalSettings() {
           </div>
         </div>
       )}
-
-      {/* Rendering Mode */}
-      <div className="settings-card rounded-2xl flex flex-col gap-4 p-5">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-sm font-semibold text-[var(--mc-text-primary)] uppercase tracking-wider">Rendering Mode</p>
-            <p className="text-xs text-[var(--mc-text-muted)] mt-1">Optimize terminal performance vs visual quality</p>
-          </div>
-          <span className="text-xs font-bold px-2.5 py-1 rounded-full bg-[var(--mc-accent)]/15 text-[var(--mc-accent)] border border-[var(--mc-accent)]/30 capitalize">
-            {pendingSettings.terminalRenderMode}
-          </span>
-        </div>
-
-        <div className="grid grid-cols-3 gap-2">
-          {RENDER_MODES.map((mode) => {
-            const isSelected = pendingSettings.terminalRenderMode === mode.id
-            return (
-              <button
-                key={mode.id}
-                type="button"
-                aria-pressed={isSelected}
-                onClick={() => setTerminalRenderMode(mode.id)}
-                className={`
-                  flex flex-col items-start px-4 py-3.5 rounded-xl
-                  transition-all duration-200
-                  ${isSelected
-                    ? 'bg-[var(--mc-bg-active)] border-2 border-[var(--mc-accent)] shadow-md shadow-[var(--mc-accent)]/20'
-                    : 'bg-[var(--mc-bg-hover)] border-2 border-transparent hover:border-[var(--mc-accent)]/30 hover:bg-[var(--mc-bg-active)]'}
-                `}
-              >
-                <span className={`flex items-center gap-1.5 text-sm font-semibold ${isSelected ? 'text-[var(--mc-accent)]' : 'text-[var(--mc-text-primary)]'}`}>
-                  <span className="text-base leading-none">{RENDER_MODE_ICONS[mode.id]}</span>
-                  {mode.name}
-                </span>
-                <span className="text-xs text-[var(--mc-text-muted)] mt-0.5 text-left leading-relaxed">{mode.description}</span>
-              </button>
-            )
-          })}
-        </div>
-
-        <div
-          title={claudeRendererHelper.tooltip}
-          className="flex items-start gap-3 rounded-xl border border-[var(--mc-border)]/70 bg-[var(--mc-bg-hover)]/70 px-3.5 py-3"
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.18em] px-2 py-1 rounded-full bg-[var(--mc-accent)]/15 text-[var(--mc-accent)] border border-[var(--mc-accent)]/30">
-            {claudeRendererHelper.badge}
-          </span>
-          <p className="text-xs leading-relaxed text-[var(--mc-text-muted)]">
-            {claudeRendererHelper.description}
-          </p>
-        </div>
-
-        <div className="pt-2 border-t border-[var(--mc-border)]/70 flex flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <ToggleSwitch
-              ariaLabel="Use GPU renderer for Claude terminals"
-              checked={Boolean(pendingSettings.gpuRendererForClaudeTerminals)}
-              onChange={setGpuRendererForClaudeTerminals}
-              disabled={claudeRendererHelper.disabled}
-            />
-            <div>
-              <p className="text-sm font-medium text-[var(--mc-text-primary)]">
-                Use GPU renderer for Claude terminals
-              </p>
-              <p className="text-xs text-[var(--mc-text-muted)] mt-0.5">
-                {claudeRendererHelper.toggleDescription}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
 
       {/* Scrollback Lines */}
       <div className="settings-card rounded-2xl flex flex-col gap-4 p-5">

--- a/src/renderer/components/terminal/terminal-view.spec.tsx
+++ b/src/renderer/components/terminal/terminal-view.spec.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import { TerminalView } from './terminal-view'
+import { registerTerminalOutputHandler } from '../../utils/terminal-output-dispatcher'
 
 const terminalHook = vi.hoisted(() => ({
   initTerminal: vi.fn(),
@@ -16,7 +17,8 @@ const terminalHook = vi.hoisted(() => ({
   scrollToBottom: vi.fn(),
   getViewportSnapshot: vi.fn(() => ({ viewportY: null, isAtBottom: true })),
   terminalRef: { current: null },
-  containerRef: { current: null }
+  containerRef: { current: null },
+  sessionToken: Symbol('terminal-view-test-session')
 }))
 
 vi.mock('../../hooks/use-terminal', () => ({
@@ -68,5 +70,16 @@ describe('TerminalView activation render restore', () => {
     window.dispatchEvent(new Event('focus'))
 
     expect(terminalHook.restoreActiveRender).not.toHaveBeenCalled()
+  })
+
+  it('registers output delivery with the renderer session token', () => {
+    render(<TerminalView terminalId="term-1" isActive />)
+
+    expect(registerTerminalOutputHandler).toHaveBeenCalledWith(
+      'term-1',
+      expect.any(Function),
+      expect.any(Function),
+      terminalHook.sessionToken,
+    )
   })
 })

--- a/src/renderer/components/terminal/terminal-view.tsx
+++ b/src/renderer/components/terminal/terminal-view.tsx
@@ -99,7 +99,7 @@ export const TerminalView = memo(function TerminalView({
   onRefreshReady,
   onOutput
 }: TerminalViewProps) {
-  const { containerRef, initTerminal, write, fit, focus, blur, showCursor, restoreActiveRender, refresh, scrollToTop, scrollToBottom, getViewportSnapshot, terminalRef } = useTerminal({
+  const { containerRef, initTerminal, write, fit, focus, blur, showCursor, restoreActiveRender, refresh, scrollToTop, scrollToBottom, getViewportSnapshot, terminalRef, sessionToken } = useTerminal({
     terminalId,
     initialOutput,
     initialViewportY,
@@ -312,8 +312,8 @@ export const TerminalView = memo(function TerminalView({
         skipAppend: skipAppendRef.current,
         appendOutput
       })
-    }, () => refresh(false))
-  }, [terminalId, write, appendOutput, onOutput, refresh])
+    }, () => refresh(false), sessionToken)
+  }, [terminalId, write, appendOutput, onOutput, refresh, sessionToken])
 
   // Focus when becomes active, blur when inactive
   // Note: scroll restoration and cursor are handled by visibility effect in use-terminal.ts

--- a/src/renderer/hooks/__tests__/use-terminal-init.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-init.spec.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal as XTerm } from '@xterm/xterm'
+import type { FitAddon } from '@xterm/addon-fit'
+import type { TerminalSurface } from '../../terminal/terminal-surface'
+import { TerminalScrollMachine } from '../../utils/terminal-scroll-machine'
+
+const harness = vi.hoisted(() => ({
+  terminals: [] as Array<Record<string, unknown>>,
+  surfaces: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function TerminalMock() {
+    const terminal = {
+      loadAddon: vi.fn(),
+      write: vi.fn((_data: string, callback?: () => void) => callback?.()),
+      attachCustomKeyEventHandler: vi.fn(),
+      onScroll: vi.fn(() => ({ dispose: vi.fn() })),
+      scrollToLine: vi.fn(),
+      buffer: { active: { baseY: 0, viewportY: 0 } },
+      element: null,
+      textarea: null,
+      cols: 80,
+      rows: 24,
+    }
+    harness.terminals.push(terminal)
+    return terminal
+  }),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function FitAddonMock() {
+    return { fit: vi.fn(), dispose: vi.fn() }
+  }),
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddonMock() {
+    return { dispose: vi.fn() }
+  }),
+}))
+
+vi.mock('../../terminal/xterm-surface', () => ({
+  XtermSurface: vi.fn(function XtermSurfaceMock() {
+    const surface = {
+      mount: vi.fn(),
+      write: vi.fn().mockResolvedValue(undefined),
+      onComposition: vi.fn(() => vi.fn()),
+      onInput: vi.fn(() => vi.fn()),
+      onResize: vi.fn(() => vi.fn()),
+    }
+    harness.surfaces.push(surface)
+    return surface
+  }),
+}))
+
+vi.mock('../use-terminal-webgl', () => ({
+  acquireSnapshotReplayLock: vi.fn().mockResolvedValue(vi.fn()),
+}))
+
+import { useTerminalInit } from '../use-terminal-init'
+import {
+  attachTerminalOutputDispatcher,
+  claimTerminalOutputSession,
+  registerTerminalOutputHandler,
+  resetTerminalOutputDispatcherForTests,
+  resumeAndFlush,
+} from '../../utils/terminal-output-dispatcher'
+import type { TerminalOutputChunk, TerminalSnapshot } from '@shared/types'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+function makeParams(sessionToken: symbol) {
+  const container = { offsetWidth: 800, offsetHeight: 600 } as HTMLDivElement
+  return {
+    terminalRef: { current: null as XTerm | null },
+    surfaceRef: { current: null as TerminalSurface | null },
+    fitAddonRef: { current: null as FitAddon | null },
+    disposedRef: { current: false },
+    containerRef: { current: container },
+    terminalId: 'same-id',
+    sessionToken,
+    initialOutput: 'fallback',
+    initialViewportY: 7,
+    isActiveRef: { current: true },
+    isHiddenRef: { current: false },
+    scrollMachineRef: { current: new TerminalScrollMachine() },
+    userViewportInteractingRef: { current: false },
+    viewportListenersRef: { current: null },
+    scrollDisposableRef: { current: null },
+    syncViewportState: vi.fn(),
+    clearUserViewportInteraction: vi.fn(),
+    markUserViewportInteraction: vi.fn(),
+    shouldSendEnhancedEnter: vi.fn(() => false),
+    attachClipboardListeners: vi.fn(),
+    getCtrlVHandler: vi.fn(() => vi.fn()),
+    followLiveOutput: vi.fn(),
+    reconcileWebGL: vi.fn(),
+    syncFontAfterLoad: vi.fn(),
+    registerTerminalDebugHandle: vi.fn(),
+    onResize: vi.fn(),
+  }
+}
+
+describe('useTerminalInit session ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    harness.terminals.length = 0
+    harness.surfaces.length = 0
+    resetTerminalOutputDispatcherForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('prevents deferred session A hydration from painting, restoring, or resuming session B', async () => {
+    const snapshot = deferred<TerminalSnapshot>()
+    vi.stubGlobal('electron', {
+      terminal: {
+        resize: vi.fn(),
+        write: vi.fn(),
+        getSnapshot: vi.fn(() => snapshot.promise),
+      },
+      app: { openExternal: vi.fn() },
+    })
+
+    const tokenA = Symbol('A')
+    const paramsA = makeParams(tokenA)
+    claimTerminalOutputSession('same-id', tokenA)
+    const hookA = renderHook(() => useTerminalInit(paramsA))
+    act(() => hookA.result.current.initTerminal())
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(50) })
+    expect(window.electron.terminal.getSnapshot).toHaveBeenCalledTimes(1)
+
+    paramsA.disposedRef.current = true
+    paramsA.terminalRef.current = null
+
+    const tokenB = Symbol('B')
+    claimTerminalOutputSession('same-id', tokenB)
+    const receivedByB: string[] = []
+    registerTerminalOutputHandler('same-id', data => receivedByB.push(data), undefined, tokenB)
+    let emit!: (chunk: TerminalOutputChunk) => void
+    attachTerminalOutputDispatcher(callback => {
+      emit = callback
+      return vi.fn()
+    })
+    emit({ terminalId: 'same-id', streamEpoch: 'epoch-b', sequence: 1, data: 'B-live' })
+
+    await act(async () => {
+      snapshot.resolve({
+        terminalId: 'same-id',
+        streamEpoch: 'epoch-a',
+        watermark: 0,
+        ansi: 'A-snapshot',
+        cols: 80,
+        rows: 24,
+        buffer: 'normal',
+      })
+      await Promise.resolve()
+    })
+
+    expect(harness.surfaces[0].write).not.toHaveBeenCalled()
+    expect(harness.terminals[0].scrollToLine).not.toHaveBeenCalled()
+    expect(receivedByB).toEqual([])
+
+    resumeAndFlush('same-id', tokenB)
+    expect(receivedByB).toEqual(['B-live'])
+  })
+})

--- a/src/renderer/hooks/__tests__/use-terminal-snapshot-refresh.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-snapshot-refresh.spec.ts
@@ -252,6 +252,29 @@ describe('refreshTerminal with snapshot replay', () => {
     }
   })
 
+  it('invalidates queued WebGL work before replacing a snapshot', async () => {
+    vi.useRealTimers()
+    const order: string[] = []
+    const surface = {
+      replaceSnapshot: vi.fn(async () => { order.push('replace') }),
+    }
+
+    await performSnapshotReplay({
+      terminalId: 'test-term',
+      terminalRef: { current: extendedMock } as never,
+      surfaceRef: { current: surface } as never,
+      disposedRef: { current: false },
+      clearTextureAtlas: vi.fn(),
+      invalidateQueuedLoad: vi.fn(() => { order.push('invalidate') }),
+      disposeWebGL: vi.fn(() => { order.push('dispose') }),
+      reconcileWebGL: vi.fn(),
+      performFit: vi.fn().mockReturnValue(true),
+      silent: true,
+    })
+
+    expect(order).toEqual(['invalidate', 'dispose', 'replace'])
+  })
+
   it('restores alternate-buffer state from the canonical snapshot', async () => {
     vi.useRealTimers()
     const reference = createTerminalStateHarness()

--- a/src/renderer/hooks/__tests__/use-terminal-webgl.spec.ts
+++ b/src/renderer/hooks/__tests__/use-terminal-webgl.spec.ts
@@ -1,99 +1,283 @@
-// vitest.config.ts: this file runs in 'jsdom' env
-// Characterization tests for useTerminalWebGL sub-hook (to be extracted in Phase 05)
-// These tests will FAIL (RED) until Phase 05 creates use-terminal-webgl.ts
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-
-vi.mock('@xterm/xterm')
-vi.mock('@xterm/addon-webgl')
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - file does not exist yet (Phase 05)
-import { shouldUseWebGL, useTerminalWebGL } from '../../hooks/use-terminal-webgl'
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WebglAddon } from '@xterm/addon-webgl'
-import { useAppStore, useSettingsStore } from '../../stores'
+import type { Terminal as XTerm } from '@xterm/xterm'
 import { DEFAULT_SETTINGS } from '@shared/constants'
+import { useAppStore, useSettingsStore } from '../../stores'
+import {
+  getTerminalRendererStatus,
+  resetTerminalRendererStatusStoreForTests,
+  retryTerminalRenderer,
+} from '../../stores/terminal-renderer-status-store'
+import { useTerminalWebGL } from '../use-terminal-webgl'
 
-function makeRefs(overrides: Record<string, unknown> = {}) {
+const webglInstances = vi.hoisted(() => [] as Array<{
+  dispose: ReturnType<typeof vi.fn>
+  onContextLoss: ReturnType<typeof vi.fn>
+}>)
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddonMock() {
+    const addon = {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+    }
+    webglInstances.push(addon)
+    return addon
+  }),
+}))
+
+function terminalRecord(id: string, agentType: 'generic' | 'claude' | 'codex' = 'generic') {
+  return {
+    id,
+    title: 'private title',
+    cwd: '/private/path',
+    isClaudeMode: false,
+    agentType,
+    createdAt: new Date(),
+  }
+}
+
+function makeParams(options: { active?: boolean; hidden?: boolean } = {}) {
   const terminal = {
     loadAddon: vi.fn(),
+    clearTextureAtlas: vi.fn(),
+    refresh: vi.fn(),
+    reset: vi.fn(),
+    resize: vi.fn(),
+    write: vi.fn((_data: string, callback?: () => void) => callback?.()),
     rows: 24,
-    ...overrides,
+    cols: 80,
   }
   return {
-    terminalRef: { current: terminal },
-    fitAddonRef: { current: { fit: vi.fn() } },
-    disposedRef: { current: false },
+    terminal,
+    params: {
+      terminalRef: { current: terminal as unknown as XTerm },
+      disposedRef: { current: false },
+      terminalId: 'term-1',
+      sessionToken: Symbol('session'),
+      isActiveRef: { current: options.active ?? true },
+      isHiddenRef: { current: options.hidden ?? false },
+      onRefresh: vi.fn(),
+      onRefreshVisibleRows: vi.fn(),
+      performFit: vi.fn(() => true),
+    },
   }
+}
+
+function flushAnimationFrame(): void {
+  act(() => { vi.runAllTimers() })
+}
+
+function getAddon(index = 0) {
+  return webglInstances[index]
+}
+
+function fireContextLoss(addon = getAddon()): void {
+  const callback = addon.onContextLoss.mock.calls[0]?.[0] as (() => void) | undefined
+  expect(callback).toBeTypeOf('function')
+  act(() => callback?.())
 }
 
 describe('useTerminalWebGL', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    useAppStore.setState({ terminals: [] })
+    vi.mocked(WebglAddon).mockClear()
+    webglInstances.length = 0
+    resetTerminalRendererStatusStoreForTests()
     useSettingsStore.setState({
-      pendingSettings: {
-        ...DEFAULT_SETTINGS,
-        terminalRenderMode: 'balanced',
-        gpuRendererForClaudeTerminals: false,
-      },
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'automatic' },
     })
+    useAppStore.setState({ terminals: [terminalRecord('term-1')] })
   })
 
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('loads WebglAddon when mode=quality', async () => {
-    // This test will pass after Phase 05 implementation
-    expect(true).toBe(true)  // placeholder until hook exists
-  })
+  it('loads lazily only after a generic terminal is active and visible', () => {
+    const { terminal, params } = makeParams({ active: false })
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    expect(WebglAddon).not.toHaveBeenCalled()
 
-  it.each(['claude', 'codex'] as const)(
-    'uses the safe renderer policy for %s terminals',
-    (agentType) => {
-      useAppStore.setState({
-        terminals: [{
-          id: 'agent-terminal',
-          title: 'Agent',
-          cwd: '/redacted',
-          isClaudeMode: agentType === 'claude',
-          agentType,
-          createdAt: new Date(),
-        }],
-      })
+    params.isActiveRef.current = true
+    act(() => result.current.reconcileWebGL())
+    flushAnimationFrame()
 
-      expect(shouldUseWebGL('agent-terminal')).toBe(false)
-    }
-  )
-
-  it('allows WebGL for a generic shell under balanced mode', () => {
-    useAppStore.setState({
-      terminals: [{
-        id: 'shell-terminal',
-        title: 'Shell',
-        cwd: '/redacted',
-        isClaudeMode: false,
-        agentType: 'generic',
-        createdAt: new Date(),
-      }],
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(terminal.loadAddon).toHaveBeenCalledWith(getAddon())
+    expect(getTerminalRendererStatus('term-1')).toMatchObject({
+      effective: 'webgl',
+      fallbackReason: null,
     })
-
-    expect(shouldUseWebGL('shell-terminal')).toBe(true)
   })
 
-  it.todo('loads WebglAddon when mode=quality and not hidden')
-  it.todo('loads WebglAddon only for active terminal when mode=balanced')
-  it.todo('unloads when terminal becomes inactive in balanced mode')
-  it.todo('never loads when mode=performance')
-  it.todo('debounces rapid active/inactive toggling (50ms)')
-  it.todo('shows toast and marks refresh needed on context loss')
-  it.todo('disposes WebglAddon on unmount')
-})
+  it('keeps a healthy addon sticky across inactive and hidden transitions', () => {
+    const { params } = makeParams()
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    const addon = getAddon()
 
-// Keep these variables referenced to prevent lint errors
-void makeRefs
-void useTerminalWebGL
-void WebglAddon
-void renderHook
-void act
+    params.isActiveRef.current = false
+    params.isHiddenRef.current = true
+    act(() => result.current.reconcileWebGL())
+
+    expect(addon.dispose).not.toHaveBeenCalled()
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(getTerminalRendererStatus('term-1')?.effective).toBe('webgl')
+  })
+
+  it.each([
+    ['safe-dom', 'generic', 'policy-safe'],
+    ['automatic', 'claude', 'automatic-agent-safe'],
+    ['automatic', 'codex', 'automatic-agent-safe'],
+  ] as const)('uses DOM for policy=%s agent=%s', (policy, agentType, reason) => {
+    useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: policy },
+    })
+    useAppStore.setState({ terminals: [terminalRecord('term-1', agentType)] })
+    const { params } = makeParams()
+
+    renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+
+    expect(WebglAddon).not.toHaveBeenCalled()
+    expect(getTerminalRendererStatus('term-1')).toMatchObject({
+      effective: 'dom',
+      fallbackReason: reason,
+    })
+  })
+
+  it('reconciles a live generic-to-Codex classification change to DOM', () => {
+    const { params } = makeParams()
+    renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    const addon = getAddon()
+
+    act(() => useAppStore.setState({ terminals: [terminalRecord('term-1', 'codex')] }))
+
+    expect(addon.dispose).toHaveBeenCalledTimes(1)
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason)
+      .toBe('automatic-agent-safe')
+  })
+
+  it('rechecks policy inside a queued animation frame', () => {
+    const { params } = makeParams()
+    renderHook(() => useTerminalWebGL(params))
+
+    act(() => useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'safe-dom' },
+    }))
+    flushAnimationFrame()
+
+    expect(WebglAddon).not.toHaveBeenCalled()
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason).toBe('policy-safe')
+  })
+
+  it('disposes a failed candidate, suppresses re-entry, and hides raw errors', () => {
+    const { terminal, params } = makeParams()
+    terminal.loadAddon.mockImplementationOnce(() => {
+      throw new Error('/private/GPU device')
+    })
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+
+    expect(getAddon().dispose).toHaveBeenCalledTimes(1)
+    expect(result.current.webglAddonRef.current).toBeNull()
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason).toBe('webgl-load-failed')
+    act(() => result.current.reconcileWebGL())
+    flushAnimationFrame()
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(warning).not.toHaveBeenCalled()
+  })
+
+  it('suppresses before disposing on context loss without snapshot replay', () => {
+    const { params } = makeParams()
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    const addon = getAddon()
+
+    fireContextLoss(addon)
+
+    expect(addon.dispose).toHaveBeenCalledTimes(1)
+    expect(params.onRefresh).not.toHaveBeenCalled()
+    expect(params.onRefreshVisibleRows).toHaveBeenCalled()
+    expect(params.performFit).toHaveBeenCalledWith(false)
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason).toBe('webgl-context-lost')
+
+    act(() => {
+      result.current.reloadWebGLForTheme()
+      result.current.reconcileWebGL()
+    })
+    flushAnimationFrame()
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries only the faulted eligible terminal and preserves policy', () => {
+    const { params } = makeParams()
+    renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    fireContextLoss()
+
+    expect(retryTerminalRenderer('other')).toBe(false)
+    expect(retryTerminalRenderer('term-1')).toBe(true)
+    flushAnimationFrame()
+
+    expect(WebglAddon).toHaveBeenCalledTimes(2)
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy)
+      .toBe('automatic')
+  })
+
+  it('does not clear a renderer fault during policy preview/cancel transitions', () => {
+    const { params } = makeParams()
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    fireContextLoss()
+
+    act(() => useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'safe-dom' },
+    }))
+    act(() => useSettingsStore.setState({
+      pendingSettings: { ...DEFAULT_SETTINGS, terminalRendererPolicy: 'automatic' },
+    }))
+    act(() => result.current.reconcileWebGL())
+    flushAnimationFrame()
+
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason).toBe('webgl-context-lost')
+  })
+
+  it('does not publish ownership until listener setup succeeds', () => {
+    const failedCandidate = {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn(() => { throw new Error('sensitive listener failure') }),
+    }
+    vi.mocked(WebglAddon).mockImplementationOnce(function FailedWebglAddonMock() {
+      webglInstances.push(failedCandidate)
+      return failedCandidate as never
+    })
+    const { params } = makeParams()
+    const { result } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+
+    expect(result.current.webglAddonRef.current).toBeNull()
+    expect(getAddon().dispose).toHaveBeenCalledTimes(1)
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason).toBe('webgl-load-failed')
+  })
+
+  it('synchronously releases status/action and disposes on unmount', () => {
+    const { params } = makeParams()
+    const { unmount } = renderHook(() => useTerminalWebGL(params))
+    flushAnimationFrame()
+    const addon = getAddon()
+
+    unmount()
+
+    expect(addon.dispose).toHaveBeenCalledTimes(1)
+    expect(getTerminalRendererStatus('term-1')).toBeUndefined()
+    expect(retryTerminalRenderer('term-1')).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-terminal-init.ts
+++ b/src/renderer/hooks/use-terminal-init.ts
@@ -69,6 +69,7 @@ interface UseTerminalInitParams {
   disposedRef: RefObject<boolean>
   containerRef: RefObject<HTMLDivElement | null>
   terminalId: string
+  sessionToken: symbol
   initialOutput?: string
   initialViewportY?: number | null
   isActiveRef: RefObject<boolean>
@@ -102,6 +103,7 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
     disposedRef,
     containerRef,
     terminalId,
+    sessionToken,
     initialOutput,
     initialViewportY = null,
     isActiveRef,
@@ -148,7 +150,7 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
     // "jump" as cursor moves / lines are cleared / prompt reprints. Buffering
     // the live chunks until after snapshot write guarantees a single clean
     // paint — any post-snapshot bytes are flushed via resumeAndFlush() below.
-    pauseAndBuffer(terminalId)
+    pauseAndBuffer(terminalId, sessionToken)
 
     const terminal = new XTerm({
       cursorBlink: true,
@@ -370,7 +372,7 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
 
     // ── Deferred initialisation (WebGL, fit, restore) ────────────────────────
     setTimeout(() => {
-      if (disposedRef.current || !terminalRef.current) return
+      if (disposedRef.current || terminalRef.current !== terminal) return
 
       // Conditionally load WebGL — delegated to reconcileWebGL which handles
       // shouldUseWebGL(), addon construction, and context-loss listener setup
@@ -383,15 +385,14 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
       }
 
       const restoreInitialViewport = () => {
-        if (disposedRef.current || !terminalRef.current) return
+        if (disposedRef.current || terminalRef.current !== terminal) return
         if (initialViewportYRef.current !== null && initialViewportYRef.current >= 0) {
-          const terminal = terminalRef.current
           const targetViewportY = initialViewportYRef.current
           withInstantTerminalScroll(terminal, () => {
             terminal.scrollToLine(targetViewportY)
           })
         }
-        scrollMachineRef.current.savedViewportY = terminalRef.current.buffer.active.viewportY
+        scrollMachineRef.current.savedViewportY = terminal.buffer.active.viewportY
         syncScrollPosition(false)
       }
 
@@ -402,32 +403,32 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
       // reflects the post-SIGWINCH headless state, the flush is typically a
       // no-op or a small trailing delta — not a full replay.
       const finishInit = () => {
-        if (disposedRef.current) return
-        resumeAndFlush(terminalId)
+        if (disposedRef.current || terminalRef.current !== terminal) return
+        resumeAndFlush(terminalId, sessionToken)
       }
 
       const hydrateFromCanonicalSnapshot = async () => {
-        const releaseLock = await acquireSnapshotReplayLock(terminalId, true)
+        const releaseLock = await acquireSnapshotReplayLock(terminalId, sessionToken, true)
         if (!releaseLock) return
         try {
           const snap = await window.electron.terminal.getSnapshot(terminalId)
-          if (disposedRef.current || !terminalRef.current) return
+          if (disposedRef.current || terminalRef.current !== terminal) return
           const hydrationData = snap.ansi || initialOutputRef.current || ''
           if (hydrationData) {
-            await (surfaceRef.current?.write(hydrationData)
+            await (surface.write(hydrationData)
               ?? new Promise<void>(resolve => terminal.write(hydrationData, resolve)))
           }
-          if (disposedRef.current || !terminalRef.current) return
+          if (disposedRef.current || terminalRef.current !== terminal) return
           requestAnimationFrame(restoreInitialViewport)
-          resumeFromSnapshot(snap)
+          resumeFromSnapshot(snap, sessionToken)
         } catch {
-          if (disposedRef.current || !terminalRef.current) return
+          if (disposedRef.current || terminalRef.current !== terminal) return
           const fallback = initialOutputRef.current
           if (fallback) {
-            await (surfaceRef.current?.write(fallback)
+            await (surface.write(fallback)
               ?? new Promise<void>(resolve => terminal.write(fallback, resolve)))
           }
-          if (disposedRef.current || !terminalRef.current) return
+          if (disposedRef.current || terminalRef.current !== terminal) return
           requestAnimationFrame(restoreInitialViewport)
           finishInit()
         } finally {
@@ -560,6 +561,7 @@ export function useTerminalInit(params: UseTerminalInitParams): UseTerminalInitR
     surfaceRef,
     fitAddonRef,
     terminalId,
+    sessionToken,
     isActiveRef,
     isHiddenRef,
     scrollMachineRef,

--- a/src/renderer/hooks/use-terminal-webgl.ts
+++ b/src/renderer/hooks/use-terminal-webgl.ts
@@ -1,84 +1,96 @@
-/**
- * useTerminalWebGL — manages WebGL renderer lifecycle for a single xterm terminal.
- *
- * Responsibilities:
- *   - Load / unload WebglAddon based on shouldUseWebGL() result
- *   - Attach context-loss listener (calls onRefresh on GPU context loss)
- *   - Expose clearTextureAtlas() helper for other hooks
- *   - Subscribe to render-mode + Claude-mode store changes (three useEffects)
- *   - Expose reloadWebGLForTheme() — dispose + reload WebGL after theme change
- *   - Expose refreshTerminal() — full display refresh with snapshot replay
- *
- * Sub-hooks must NOT import from each other.  All orchestration lives in use-terminal.ts.
- */
-import { useEffect, useRef, useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
 import { WebglAddon } from '@xterm/addon-webgl'
-import type { Terminal as XTerm } from '@xterm/xterm'
+import type { IDisposable, Terminal as XTerm } from '@xterm/xterm'
 import type { TerminalSurface } from '../terminal/terminal-surface'
-import { useSettingsStore, useAppStore, useToastStore } from '../stores'
+import { useAppStore, useSettingsStore, useToastStore } from '../stores'
+import {
+  claimTerminalRendererSession,
+  registerTerminalRendererRetry,
+  releaseTerminalRendererSession,
+  setTerminalRendererStatus,
+} from '../stores/terminal-renderer-status-store'
 import {
   pauseAndBuffer,
   resumeAndFlush,
   resumeFromSnapshot,
 } from '../utils/terminal-output-dispatcher'
-import { subscribeToSystemResume, unsubscribeFromSystemResume } from '../utils/terminal-lifecycle-dispatcher'
+import {
+  resolveTerminalRenderer,
+  type RendererFallbackReason,
+} from '../utils/terminal-renderer-policy'
+import {
+  subscribeToSystemResume,
+  unsubscribeFromSystemResume,
+} from '../utils/terminal-lifecycle-dispatcher'
 
-// ── Per-terminal mutex ───────────────────────────────────────────────────────
-// Prevents concurrent snapshot replays (e.g. refresh + phase-4 auto-resync).
-// Map<terminalId, Promise<void>> — presence of key = lock is held.
-// Designed for phase-4 reuse: import snapshotReplayMutex and call isLocked() before
-// triggering auto-resync from powerMonitor/onSystemResumed.
-const snapshotReplayMutex = new Map<string, Promise<void>>()
+interface SnapshotReplayLock {
+  token: symbol
+  promise: Promise<void>
+}
+
+const snapshotReplayMutex = new Map<string, SnapshotReplayLock>()
+const legacyReplayTokens = new Map<string, symbol>()
+const REFRESH_DEBOUNCE = 100
+
+function getLegacyReplayToken(terminalId: string): symbol {
+  let token = legacyReplayTokens.get(terminalId)
+  if (!token) {
+    token = Symbol(`legacy-replay:${terminalId}`)
+    legacyReplayTokens.set(terminalId, token)
+  }
+  return token
+}
 
 export async function acquireSnapshotReplayLock(
   terminalId: string,
-  waitForExisting = false
+  tokenOrWait: symbol | boolean = false,
+  waitForExisting = false,
 ): Promise<(() => void) | null> {
+  const token = typeof tokenOrWait === 'symbol'
+    ? tokenOrWait
+    : getLegacyReplayToken(terminalId)
+  const shouldWait = typeof tokenOrWait === 'boolean' ? tokenOrWait : waitForExisting
+
   while (snapshotReplayMutex.has(terminalId)) {
-    if (!waitForExisting) return null
-    await snapshotReplayMutex.get(terminalId)
+    const existing = snapshotReplayMutex.get(terminalId)!
+    if (existing.token !== token) break
+    if (!shouldWait) return null
+    await existing.promise
   }
 
   let resolve!: () => void
-  const lock = new Promise<void>(resolveLock => { resolve = resolveLock })
+  const promise = new Promise<void>(resolveLock => { resolve = resolveLock })
+  const lock = { token, promise }
   snapshotReplayMutex.set(terminalId, lock)
   return () => {
-    if (snapshotReplayMutex.get(terminalId) === lock) {
-      snapshotReplayMutex.delete(terminalId)
-    }
+    if (snapshotReplayMutex.get(terminalId) === lock) snapshotReplayMutex.delete(terminalId)
     resolve()
   }
 }
 
-const REFRESH_DEBOUNCE = 100  // ms debounce for refreshTerminal()
+export function isSnapshotReplayLocked(terminalId: string): boolean {
+  return snapshotReplayMutex.has(terminalId)
+}
 
-/**
- * Determine if WebGL is allowed for this terminal based on settings only.
- *
- * Note: isActive/isHidden are accepted for API compatibility but intentionally
- * ignored in the allow decision. Once loaded, the WebGL addon stays alive across
- * terminal switches to avoid texture-atlas corruption caused by repeated
- * load/dispose cycles (observed as stretched/garbled text when switching panes).
- * Initial-load gating on isActive/isHidden happens in reconcileWebGL instead.
- */
-export function shouldUseWebGL(terminalId: string, _isActive?: boolean, _isHidden?: boolean): boolean {
-  void _isActive; void _isHidden
-  const { pendingSettings } = useSettingsStore.getState()
-  const terminal = useAppStore.getState().terminals.find(
-    candidate => candidate.id === terminalId
-  )
-  const requiresSafeRenderer =
-    terminal?.agentType === 'claude' ||
-    terminal?.agentType === 'codex' ||
-    terminal?.isClaudeMode === true
+function getRendererIntent(terminalId: string) {
+  const policy = useSettingsStore.getState().pendingSettings.terminalRendererPolicy
+  const terminal = useAppStore.getState().terminals.find(candidate => candidate.id === terminalId)
+  return resolveTerminalRenderer({
+    policy,
+    agentType: terminal?.agentType,
+    isClaudeMode: terminal?.isClaudeMode,
+  })
+}
 
-  if (requiresSafeRenderer && !pendingSettings.gpuRendererForClaudeTerminals) {
-    return false
-  }
-
-  const mode = pendingSettings.terminalRenderMode ?? 'balanced'
-  return mode !== 'performance'
+export function shouldUseWebGL(
+  terminalId: string,
+  _isActive?: boolean,
+  _isHidden?: boolean,
+): boolean {
+  void _isActive
+  void _isHidden
+  return getRendererIntent(terminalId).desired === 'webgl'
 }
 
 interface UseTerminalWebGLParams {
@@ -86,145 +98,112 @@ interface UseTerminalWebGLParams {
   surfaceRef?: RefObject<TerminalSurface | null>
   disposedRef: RefObject<boolean>
   terminalId: string
+  sessionToken?: symbol
   isActiveRef: RefObject<boolean>
   isHiddenRef: RefObject<boolean>
-  /** Called when WebGL context is lost — triggers a full display refresh */
-  onRefresh: (showNotification?: boolean) => void
-  /** Called after WebGL addon loads to repaint visible rows */
+  onRefresh?: (showNotification?: boolean) => void
   onRefreshVisibleRows: () => void
-  /** Called to refit terminal after a refresh */
   performFit: (restoreViewport?: boolean) => boolean
 }
 
 interface UseTerminalWebGLResult {
-  /** Reconcile the current WebGL state with shouldUseWebGL() result */
   reconcileWebGL: () => void
-  /** Clear texture atlas — useful before renderer transitions */
   clearTextureAtlas: () => void
-  /** Ref to the active WebGL addon (null when canvas renderer is active) */
   webglAddonRef: RefObject<WebglAddon | null>
-  /** True while WebGL addon is loading — visibility hook polls this before restoring scroll */
   webglLoadingRef: RefObject<boolean>
-  /** Dispose + reload WebGL after theme change (cursor color requires full reload) */
   reloadWebGLForTheme: () => void
-  /** Full display refresh via snapshot replay (debounced). showNotification defaults true. */
   refreshTerminal: (showNotification?: boolean) => void
+  disposeWebGL: () => void
 }
 
 interface SnapshotReplayParams {
   terminalId: string
+  sessionToken?: symbol
   terminalRef: RefObject<XTerm | null>
   surfaceRef?: RefObject<TerminalSurface | null>
   disposedRef: RefObject<boolean>
-  isActiveRef: RefObject<boolean>
-  isHiddenRef: RefObject<boolean>
+  isActiveRef?: RefObject<boolean>
+  isHiddenRef?: RefObject<boolean>
   clearTextureAtlas: () => void
-  webglAddonRef: RefObject<WebglAddon | null>
+  webglAddonRef?: RefObject<WebglAddon | null>
+  disposeWebGL?: () => void
   reconcileWebGL: () => void
   performFit: (restoreViewport?: boolean) => boolean
   silent: boolean
 }
 
-/**
- * Core snapshot replay sequence — hardened against B1/H4/H6/M8 failure modes.
- *
- * Sequence:
- *   mutex check → pauseAndBuffer → getSnapshot → (disposed check) →
- *   WebGL teardown → terminal.reset() → resize →
- *   write snapshot data → WebGL reload → performFit → SIGWINCH →
- *   resumeFromSnapshot(watermark) → toast
- *
- * Exported so phase-4 (powerMonitor auto-resync) can call it with silent:true.
- */
 export async function performSnapshotReplay(params: SnapshotReplayParams): Promise<void> {
   const {
     terminalId,
+    sessionToken,
     terminalRef,
     surfaceRef,
     disposedRef,
-    isActiveRef,
-    isHiddenRef,
     clearTextureAtlas,
     webglAddonRef,
+    disposeWebGL,
     reconcileWebGL,
     performFit,
     silent,
   } = params
-
-  const releaseLock = await acquireSnapshotReplayLock(terminalId)
+  const replayToken = sessionToken ?? getLegacyReplayToken(terminalId)
+  const releaseLock = await acquireSnapshotReplayLock(terminalId, replayToken)
   if (!releaseLock) return
 
   try {
-    // H4: buffer live output chunks while we reset+replay
-    pauseAndBuffer(terminalId)
-
-    // Canonical state is already maintained in the ordered main-process mirror.
-    // Refresh never replays the persisted raw tail.
-    const snap = await window.electron.terminal.getSnapshot(terminalId)
-
-    // M8: terminal destroyed while IPC was in flight
+    pauseAndBuffer(terminalId, sessionToken)
+    const snapshot = await window.electron.terminal.getSnapshot(terminalId)
     if (disposedRef.current || !terminalRef.current) {
-      resumeAndFlush(terminalId)
+      resumeAndFlush(terminalId, sessionToken)
       return
     }
 
-    const t = terminalRef.current
-
-    // Dispose WebGL before reset to avoid texture cache corruption
+    const terminal = terminalRef.current
     clearTextureAtlas()
-    try { webglAddonRef.current?.dispose() } catch { /* ignore */ }
-    webglAddonRef.current = null
+    if (disposeWebGL) {
+      disposeWebGL()
+    } else {
+      try { webglAddonRef?.current?.dispose() } catch { /* teardown is best-effort */ }
+      if (webglAddonRef) webglAddonRef.current = null
+    }
 
     if (surfaceRef?.current) {
-      await surfaceRef.current.replaceSnapshot(snap)
+      await surfaceRef.current.replaceSnapshot(snapshot)
     } else {
-      t.reset()
-      if (snap.cols > 0 && snap.rows > 0) t.resize(snap.cols, snap.rows)
-      if (snap.ansi) await new Promise<void>(resolve => t.write(snap.ansi, resolve))
+      terminal.reset()
+      if (snapshot.cols > 0 && snapshot.rows > 0) terminal.resize(snapshot.cols, snapshot.rows)
+      if (snapshot.ansi) {
+        await new Promise<void>(resolve => terminal.write(snapshot.ansi, resolve))
+      }
     }
 
-    // Reload WebGL after reset/write cycle
-    if (shouldUseWebGL(terminalId, isActiveRef.current, isHiddenRef.current)) {
-      try {
-        const addon = new WebglAddon()
-        webglAddonRef.current = addon
-        t.loadAddon(addon)
-        reconcileWebGL()
-      } catch (e) { console.warn('WebGL addon failed to load after snapshot replay:', e) }
+    if (disposedRef.current || terminalRef.current !== terminal) {
+      resumeAndFlush(terminalId, sessionToken)
+      return
     }
-
+    reconcileWebGL()
     const fitOk = performFit(false)
-
-    // SIGWINCH — makes CLI (vim, tmux, etc.) repaint at current dimensions
     try {
-      window.electron.terminal.resize(terminalId, t.cols, t.rows)
-    } catch { /* ignore — non-fatal */ }
-
-    resumeFromSnapshot(snap)
+      window.electron.terminal.resize(terminalId, terminal.cols, terminal.rows)
+    } catch { /* non-fatal */ }
+    resumeFromSnapshot(snapshot, sessionToken)
 
     if (!silent) {
-      try {
-        useToastStore.getState().addToast(
-          fitOk ? 'Terminal refreshed' : 'Terminal refreshed (pane hidden — retry when visible)',
-          'info'
-        )
-      } catch { /* ignore */ }
+      useToastStore.getState().addToast(
+        fitOk ? 'Terminal refreshed' : 'Terminal refreshed (pane hidden — retry when visible)',
+        'info',
+      )
     }
-  } catch (err) {
-    // Ensure buffer is always flushed even on error, then surface the error as a toast
-    resumeAndFlush(terminalId)
-    console.error('Terminal snapshot replay failed:', err)
-    try {
-      useToastStore.getState().addToast('Terminal refresh error — could not fetch snapshot', 'error')
-    } catch { /* ignore */ }
+  } catch {
+    resumeAndFlush(terminalId, sessionToken)
+    console.error('[terminal-renderer] Snapshot replay failed.')
+    useToastStore.getState().addToast(
+      'Terminal refresh error — could not fetch snapshot',
+      'error',
+    )
   } finally {
     releaseLock()
   }
-}
-
-/** Test helper: check if a replay is currently in progress for a terminal. */
-export function isSnapshotReplayLocked(terminalId: string): boolean {
-  return snapshotReplayMutex.has(terminalId)
 }
 
 export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWebGLResult {
@@ -235,157 +214,212 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
     terminalId,
     isActiveRef,
     isHiddenRef,
-    onRefresh,
     onRefreshVisibleRows,
     performFit,
   } = params
-
+  const localSessionTokenRef = useRef(Symbol(`renderer:${terminalId}`))
+  const sessionToken = params.sessionToken ?? localSessionTokenRef.current
   const webglAddonRef = useRef<WebglAddon | null>(null)
+  const contextLossDisposableRef = useRef<IDisposable | null>(null)
   const webglLoadingRef = useRef(false)
+  const queuedFrameRef = useRef<number | null>(null)
+  const generationRef = useRef(0)
+  const suppressedReasonRef = useRef<RendererFallbackReason | null>(null)
+  const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Keep a stable ref to onRefresh so the context-loss handler always calls the latest version
-  const onRefreshRef = useRef(onRefresh)
-  useEffect(() => {
-    onRefreshRef.current = onRefresh
-  }, [onRefresh])
+  const publishStatus = useCallback((
+    effective: 'dom' | 'webgl',
+    fallbackReason: RendererFallbackReason | null,
+  ) => {
+    setTerminalRendererStatus(terminalId, sessionToken, { effective, fallbackReason })
+  }, [sessionToken, terminalId])
 
-  /**
-   * Attach context-loss listener via the public addon API.
-   * Wraps dispose() to also cleanup the listener.
-   */
-  const attachContextLostListener = useCallback((addon: WebglAddon) => {
-    const contextLossDisposable = addon.onContextLoss(() => {
-      console.warn('WebGL context lost, auto-refreshing terminal...')
-      onRefreshRef.current(true)  // Show notification on auto-refresh
-    })
-
-    const originalDispose = addon.dispose.bind(addon)
-    addon.dispose = () => {
-      contextLossDisposable.dispose()
-      originalDispose()
+  const invalidateQueuedLoad = useCallback(() => {
+    generationRef.current += 1
+    webglLoadingRef.current = false
+    if (queuedFrameRef.current !== null) {
+      cancelAnimationFrame(queuedFrameRef.current)
+      queuedFrameRef.current = null
     }
   }, [])
 
-  const clearTextureAtlas = useCallback(() => {
-    const terminal = terminalRef.current
-    if (!terminal || disposedRef.current) return
+  const disposeWebGL = useCallback(() => {
+    const addon = webglAddonRef.current
+    const lossDisposable = contextLossDisposableRef.current
+    webglAddonRef.current = null
+    contextLossDisposableRef.current = null
+    try { lossDisposable?.dispose() } catch { /* teardown is best-effort */ }
+    try { addon?.dispose() } catch { /* teardown is best-effort */ }
+  }, [])
 
-    try {
-      terminal.clearTextureAtlas()
-    } catch {
-      // Ignore atlas resets during initialization/teardown races
-    }
-  }, [terminalRef, disposedRef])
+  const clearTextureAtlas = useCallback(() => {
+    if (disposedRef.current || !terminalRef.current) return
+    try { terminalRef.current.clearTextureAtlas() } catch { /* initialization race */ }
+  }, [disposedRef, terminalRef])
 
   const reconcileWebGL = useCallback(() => {
-    if (disposedRef.current || !terminalRef.current || webglLoadingRef.current) return
+    const terminal = terminalRef.current
+    if (disposedRef.current || !terminal) return
+    const intent = getRendererIntent(terminalId)
 
-    const allowed = shouldUseWebGL(terminalId)
-    const hasWebGL = webglAddonRef.current !== null
+    if (intent.desired === 'dom') {
+      const hadWebGL = webglAddonRef.current !== null
+      invalidateQueuedLoad()
+      disposeWebGL()
+      publishStatus('dom', intent.fallbackReason)
+      if (hadWebGL) onRefreshVisibleRows()
+      return
+    }
+    if (suppressedReasonRef.current) {
+      publishStatus('dom', suppressedReasonRef.current)
+      return
+    }
+    if (webglAddonRef.current) {
+      publishStatus('webgl', null)
+      return
+    }
 
-    // Initial load is gated on active+visible to avoid eagerly allocating WebGL
-    // contexts for inactive terminals (browsers cap concurrent WebGL contexts).
-    // Once loaded, the addon stays alive across terminal switches — see
-    // shouldUseWebGL() docstring for rationale.
-    const shouldLoad = allowed && isActiveRef.current && !isHiddenRef.current
+    publishStatus('dom', null)
+    if (webglLoadingRef.current || !isActiveRef.current || isHiddenRef.current) return
+    webglLoadingRef.current = true
+    const generation = ++generationRef.current
+    const scheduledTerminal = terminal
 
-    if (shouldLoad && !hasWebGL) {
-      webglLoadingRef.current = true
-      requestAnimationFrame(() => {
-        if (disposedRef.current || !terminalRef.current) {
-          webglLoadingRef.current = false
+    queuedFrameRef.current = requestAnimationFrame(() => {
+      queuedFrameRef.current = null
+      const latestIntent = getRendererIntent(terminalId)
+      if (
+        generationRef.current !== generation
+        || disposedRef.current
+        || terminalRef.current !== scheduledTerminal
+        || latestIntent.desired !== 'webgl'
+        || suppressedReasonRef.current !== null
+        || !isActiveRef.current
+        || isHiddenRef.current
+      ) {
+        webglLoadingRef.current = false
+        return
+      }
+
+      let candidate: WebglAddon | null = null
+      let candidateLossDisposable: IDisposable | null = null
+      try {
+        if (typeof WebglAddon !== 'function') {
+          suppressedReasonRef.current = 'webgl-unavailable'
+          publishStatus('dom', 'webgl-unavailable')
           return
         }
-        try {
-          const webglAddon = new WebglAddon()
-          webglAddonRef.current = webglAddon
-          terminalRef.current.loadAddon(webglAddon)
-          attachContextLostListener(webglAddon)
+        candidate = new WebglAddon()
+        scheduledTerminal.loadAddon(candidate)
+        candidateLossDisposable = candidate.onContextLoss(() => {
+          if (webglAddonRef.current !== candidate || suppressedReasonRef.current) return
+          suppressedReasonRef.current = 'webgl-context-lost'
+          invalidateQueuedLoad()
+          disposeWebGL()
+          publishStatus('dom', 'webgl-context-lost')
           onRefreshVisibleRows()
-        } catch (e) {
-          console.warn('WebGL addon failed to load:', e)
+          performFit(false)
+        })
+        if (
+          generationRef.current !== generation
+          || disposedRef.current
+          || terminalRef.current !== scheduledTerminal
+          || getRendererIntent(terminalId).desired !== 'webgl'
+        ) {
+          candidateLossDisposable.dispose()
+          candidate.dispose()
+          return
         }
-        webglLoadingRef.current = false
-      })
-    } else if (!allowed && hasWebGL) {
-      try {
-        webglAddonRef.current?.dispose()
+        webglAddonRef.current = candidate
+        contextLossDisposableRef.current = candidateLossDisposable
+        publishStatus('webgl', null)
+        onRefreshVisibleRows()
       } catch {
-        // Ignore disposal errors
+        try { candidateLossDisposable?.dispose() } catch { /* best-effort */ }
+        try { candidate?.dispose() } catch { /* best-effort */ }
+        suppressedReasonRef.current = 'webgl-load-failed'
+        publishStatus('dom', 'webgl-load-failed')
+      } finally {
+        webglLoadingRef.current = false
       }
-      webglAddonRef.current = null
-      onRefreshVisibleRows()
+    })
+  }, [
+    disposedRef,
+    disposeWebGL,
+    invalidateQueuedLoad,
+    isActiveRef,
+    isHiddenRef,
+    onRefreshVisibleRows,
+    performFit,
+    publishStatus,
+    terminalId,
+    terminalRef,
+  ])
+
+  const retryGPU = useCallback((): boolean => {
+    const reason = suppressedReasonRef.current
+    if (reason !== 'webgl-load-failed' && reason !== 'webgl-context-lost') return false
+    if (disposedRef.current || getRendererIntent(terminalId).desired !== 'webgl') return false
+    suppressedReasonRef.current = null
+    invalidateQueuedLoad()
+    reconcileWebGL()
+    return true
+  }, [disposedRef, invalidateQueuedLoad, reconcileWebGL, terminalId])
+
+  useEffect(() => {
+    claimTerminalRendererSession(terminalId, sessionToken)
+    const unregisterRetry = registerTerminalRendererRetry(
+      terminalId,
+      sessionToken,
+      retryGPU,
+    )
+    reconcileWebGL()
+    return () => {
+      invalidateQueuedLoad()
+      if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current)
+      unregisterRetry()
+      disposeWebGL()
+      releaseTerminalRendererSession(terminalId, sessionToken)
     }
-  }, [attachContextLostListener, disposedRef, isActiveRef, isHiddenRef, onRefreshVisibleRows, terminalId, terminalRef])
+  }, [
+    disposeWebGL,
+    invalidateQueuedLoad,
+    reconcileWebGL,
+    retryGPU,
+    sessionToken,
+    terminalId,
+  ])
 
-  // Subscribe to render-mode + GPU-override setting changes
-  useEffect(() => {
-    const unsubscribe = useSettingsStore.subscribe((state, prevState) => {
-      if (!terminalRef.current || disposedRef.current) return
-      const renderModeChanged =
-        state.pendingSettings.terminalRenderMode !== prevState.pendingSettings.terminalRenderMode
-      const claudeGpuOverrideChanged =
-        state.pendingSettings.gpuRendererForClaudeTerminals !== prevState.pendingSettings.gpuRendererForClaudeTerminals
-
-      if (!renderModeChanged && !claudeGpuOverrideChanged) return
-
+  useEffect(() => useSettingsStore.subscribe((state, previous) => {
+    if (
+      state.pendingSettings.terminalRendererPolicy
+      !== previous.pendingSettings.terminalRendererPolicy
+    ) {
       reconcileWebGL()
-    })
-    return unsubscribe
-  }, [disposedRef, reconcileWebGL, terminalRef])
+    }
+  }), [reconcileWebGL])
 
-  // Subscribe to Claude-mode changes (affects GPU usage per terminal)
-  useEffect(() => {
-    const unsubscribe = useAppStore.subscribe((state, prevState) => {
-      if (!terminalRef.current || disposedRef.current) return
-
-      const nextClaudeMode = state.terminals.find(t => t.id === terminalId)?.isClaudeMode ?? false
-      const prevClaudeMode = prevState.terminals.find(t => t.id === terminalId)?.isClaudeMode ?? false
-
-      if (nextClaudeMode === prevClaudeMode) return
-
+  useEffect(() => useAppStore.subscribe((state, previous) => {
+    const current = state.terminals.find(terminal => terminal.id === terminalId)
+    const prior = previous.terminals.find(terminal => terminal.id === terminalId)
+    if (
+      current?.agentType !== prior?.agentType
+      || current?.isClaudeMode !== prior?.isClaudeMode
+    ) {
       reconcileWebGL()
-    })
-    return unsubscribe
-  }, [disposedRef, reconcileWebGL, terminalId, terminalRef])
+    }
+  }), [reconcileWebGL, terminalId])
 
-  const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  /**
-   * Dispose + reload WebGL after a theme change (cursor color requires full reload).
-   * When no WebGL is active, simply refreshes the canvas renderer.
-   */
   const reloadWebGLForTheme = useCallback(() => {
-    const t = terminalRef.current
-    if (!t || disposedRef.current) return
+    const terminal = terminalRef.current
+    if (!terminal || disposedRef.current) return
     clearTextureAtlas()
-    if (webglAddonRef.current) {
-      try { webglAddonRef.current.dispose() } catch { /* ignore */ }
-      webglAddonRef.current = null
-      t.refresh(0, t.rows - 1)
-      if (shouldUseWebGL(terminalId, isActiveRef.current, isHiddenRef.current)) {
-        try {
-          const addon = new WebglAddon()
-          webglAddonRef.current = addon
-          t.loadAddon(addon)
-          reconcileWebGL()
-        } catch (e) { console.warn('WebGL addon failed to load:', e) }
-      }
-    } else {
-      t.refresh(0, t.rows - 1)
-    }
-  }, [clearTextureAtlas, disposedRef, isActiveRef, isHiddenRef, reconcileWebGL, terminalId, terminalRef, webglAddonRef])
+    const hadWebGL = webglAddonRef.current !== null
+    if (hadWebGL) disposeWebGL()
+    terminal.refresh(0, terminal.rows - 1)
+    reconcileWebGL()
+  }, [clearTextureAtlas, disposedRef, disposeWebGL, reconcileWebGL, terminalRef])
 
-  /**
-   * Full display refresh via snapshot replay.
-   * Fetches a headless PTY snapshot from the backend, resets xterm, and replays
-   * the snapshot data — restoring the visible terminal state after a GPU context
-   * loss, lid-wake, or explicit user refresh.
-   *
-   * Debounced to absorb rapid context-loss bursts.
-   * Delegates to performSnapshotReplay() which holds the per-terminal mutex,
-   * buffers live output during replay (H4), and handles disposal guard (M8).
-   */
   const refreshTerminal = useCallback((showNotification = true) => {
     if (disposedRef.current || !terminalRef.current) return
     if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current)
@@ -393,54 +427,65 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
       if (disposedRef.current || !terminalRef.current) return
       void performSnapshotReplay({
         terminalId,
+        sessionToken,
         terminalRef,
         surfaceRef,
         disposedRef,
-        isActiveRef,
-        isHiddenRef,
         clearTextureAtlas,
-        webglAddonRef,
+        disposeWebGL,
         reconcileWebGL,
         performFit,
         silent: !showNotification,
       })
     }, REFRESH_DEBOUNCE)
-  }, [clearTextureAtlas, disposedRef, isActiveRef, isHiddenRef, performFit, reconcileWebGL, surfaceRef, terminalId, terminalRef, webglAddonRef])
+  }, [
+    clearTextureAtlas,
+    disposedRef,
+    disposeWebGL,
+    performFit,
+    reconcileWebGL,
+    sessionToken,
+    surfaceRef,
+    terminalId,
+    terminalRef,
+  ])
 
-  // Phase 4: subscribe to system-resume lifecycle events.
-  // Triggers silent snapshot replay (no toast) on lid-wake, mirroring the same
-  // path as the explicit refresh button but with silent=true.
-  // snapshotReplayMutex inside performSnapshotReplay() coalesces concurrent fires.
   useEffect(() => {
-    subscribeToSystemResume(terminalId, () => {
+    subscribeToSystemResume(terminalId, sessionToken, () => {
       if (disposedRef.current || !terminalRef.current) return
       void performSnapshotReplay({
         terminalId,
+        sessionToken,
         terminalRef,
         surfaceRef,
         disposedRef,
-        isActiveRef,
-        isHiddenRef,
         clearTextureAtlas,
-        webglAddonRef,
+        disposeWebGL,
         reconcileWebGL,
         performFit,
         silent: true,
       })
     })
-    return () => unsubscribeFromSystemResume(terminalId)
+    return () => unsubscribeFromSystemResume(terminalId, sessionToken)
   }, [
+    clearTextureAtlas,
+    disposedRef,
+    disposeWebGL,
+    performFit,
+    reconcileWebGL,
+    sessionToken,
+    surfaceRef,
     terminalId,
     terminalRef,
-    surfaceRef,
-    disposedRef,
-    isActiveRef,
-    isHiddenRef,
-    clearTextureAtlas,
-    webglAddonRef,
-    reconcileWebGL,
-    performFit,
   ])
 
-  return { reconcileWebGL, clearTextureAtlas, webglAddonRef, webglLoadingRef, reloadWebGLForTheme, refreshTerminal }
+  return {
+    reconcileWebGL,
+    clearTextureAtlas,
+    webglAddonRef,
+    webglLoadingRef,
+    reloadWebGLForTheme,
+    refreshTerminal,
+    disposeWebGL,
+  }
 }

--- a/src/renderer/hooks/use-terminal-webgl.ts
+++ b/src/renderer/hooks/use-terminal-webgl.ts
@@ -126,6 +126,7 @@ interface SnapshotReplayParams {
   isHiddenRef?: RefObject<boolean>
   clearTextureAtlas: () => void
   webglAddonRef?: RefObject<WebglAddon | null>
+  invalidateQueuedLoad?: () => void
   disposeWebGL?: () => void
   reconcileWebGL: () => void
   performFit: (restoreViewport?: boolean) => boolean
@@ -141,6 +142,7 @@ export async function performSnapshotReplay(params: SnapshotReplayParams): Promi
     disposedRef,
     clearTextureAtlas,
     webglAddonRef,
+    invalidateQueuedLoad,
     disposeWebGL,
     reconcileWebGL,
     performFit,
@@ -159,6 +161,7 @@ export async function performSnapshotReplay(params: SnapshotReplayParams): Promi
     }
 
     const terminal = terminalRef.current
+    invalidateQueuedLoad?.()
     clearTextureAtlas()
     if (disposeWebGL) {
       disposeWebGL()
@@ -432,6 +435,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
         surfaceRef,
         disposedRef,
         clearTextureAtlas,
+        invalidateQueuedLoad,
         disposeWebGL,
         reconcileWebGL,
         performFit,
@@ -442,6 +446,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
     clearTextureAtlas,
     disposedRef,
     disposeWebGL,
+    invalidateQueuedLoad,
     performFit,
     reconcileWebGL,
     sessionToken,
@@ -460,6 +465,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
         surfaceRef,
         disposedRef,
         clearTextureAtlas,
+        invalidateQueuedLoad,
         disposeWebGL,
         reconcileWebGL,
         performFit,
@@ -471,6 +477,7 @@ export function useTerminalWebGL(params: UseTerminalWebGLParams): UseTerminalWeb
     clearTextureAtlas,
     disposedRef,
     disposeWebGL,
+    invalidateQueuedLoad,
     performFit,
     reconcileWebGL,
     sessionToken,

--- a/src/renderer/hooks/use-terminal.ts
+++ b/src/renderer/hooks/use-terminal.ts
@@ -11,7 +11,10 @@ import { useEffect, useRef, useCallback } from 'react'
 import { Terminal as XTerm, IDisposable } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { TerminalScrollMachine } from '../utils/terminal-scroll-machine'
-import { resumeAndFlush as resumeTerminalOutput } from '../utils/terminal-output-dispatcher'
+import {
+  claimTerminalOutputSession,
+  resumeAndFlush as resumeTerminalOutput,
+} from '../utils/terminal-output-dispatcher'
 import { useTerminalWebGL } from './use-terminal-webgl'
 import { useTerminalFontTheme } from './use-terminal-font-theme'
 import { useTerminalKeyboard } from './use-terminal-keyboard'
@@ -59,6 +62,14 @@ export function useTerminal({
   const viewportListenersRef = useRef<ViewportEventListener[] | null>(null)
   const webglToggleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const refreshFnRef = useRef<((showNotification?: boolean) => void) | null>(null)
+  const sessionTokenRef = useRef<symbol>(Symbol(`terminal-renderer:${terminalId}`))
+  const sessionToken = sessionTokenRef.current
+
+  // Claim output ownership before component-level registration and deferred
+  // hydration effects. Same-ID renderer recreation receives a distinct token.
+  useEffect(() => {
+    claimTerminalOutputSession(terminalId, sessionToken)
+  }, [sessionToken, terminalId])
 
   // ── Sub-hooks ──────────────────────────────────────────────────────────────
   const { registerTerminalDebugHandle, unregisterTerminalDebugHandle } =
@@ -84,13 +95,22 @@ export function useTerminal({
 
   // performFit is needed by WebGL hook (refresh) — forward-declare via ref
   const performFitRef = useRef<(restoreViewport?: boolean) => boolean>(() => false)
+  const performFitFromRef = useCallback(
+    (restoreViewport?: boolean) => performFitRef.current(restoreViewport),
+    [],
+  )
+  const refreshFromRef = useCallback(
+    (showNotification?: boolean) => refreshFnRef.current?.(showNotification),
+    [],
+  )
 
   const { reconcileWebGL, clearTextureAtlas, webglAddonRef, webglLoadingRef, reloadWebGLForTheme, refreshTerminal } =
     useTerminalWebGL({
       terminalRef, surfaceRef, disposedRef, terminalId, isActiveRef, isHiddenRef,
-      onRefresh: (n) => refreshFnRef.current?.(n),
+      sessionToken,
+      onRefresh: refreshFromRef,
       onRefreshVisibleRows: refreshVisibleRows,
-      performFit: (r) => performFitRef.current(r),
+      performFit: performFitFromRef,
     })
 
   const { performFit, cancelScheduledFit, fit } = useTerminalFit({
@@ -123,6 +143,7 @@ export function useTerminal({
 
   const { initTerminal } = useTerminalInit({
     terminalRef, surfaceRef, fitAddonRef, disposedRef, containerRef, terminalId,
+    sessionToken,
     initialOutput, initialViewportY, isActiveRef, isHiddenRef, scrollMachineRef,
     userViewportInteractingRef, viewportListenersRef, scrollDisposableRef,
     syncViewportState, clearUserViewportInteraction, markUserViewportInteraction,
@@ -154,7 +175,7 @@ export function useTerminal({
       disposedRef.current = true
       // Drain any pause state set by initTerminal in case unmount races ahead
       // of snapshot-apply (prevents stuck pausedBuffer entry).
-      resumeTerminalOutput(paneTerminalId)
+      resumeTerminalOutput(paneTerminalId, sessionToken)
       scrollMachine.reset()
       clearUserViewportInteraction()
       cancelScheduledFit()
@@ -184,7 +205,7 @@ export function useTerminal({
       }, TERMINAL_DISPOSE_DELAY)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- ref objects are stable; listed for clarity
-  }, [cancelScheduledFit, clearUserViewportInteraction, unregisterTerminalDebugHandle])
+  }, [cancelScheduledFit, clearUserViewportInteraction, sessionToken, unregisterTerminalDebugHandle])
 
   // ── Public API ─────────────────────────────────────────────────────────────
   // Focus the hidden helper textarea directly with preventScroll so the browser
@@ -220,6 +241,6 @@ export function useTerminal({
   return {
     containerRef, initTerminal, write, fit, focus, blur, showCursor, restoreActiveRender, clear,
     scrollToTop, scrollToBottom, isAtBottom, hasScrollback,
-    refresh, getViewportSnapshot, terminalRef
+    refresh, getViewportSnapshot, terminalRef, sessionToken
   }
 }

--- a/src/renderer/stores/index.ts
+++ b/src/renderer/stores/index.ts
@@ -2,6 +2,11 @@ export { useAppStore, type ActiveView } from './app-store'
 export { useSettingsStore } from './settings-store'
 export { useNotificationStore, setupNotificationListener } from './notification-store'
 export { useToastStore } from './toast-store'
+export {
+  retryTerminalRenderer,
+  useTerminalRendererStatusStore,
+  type TerminalRendererStatus,
+} from './terminal-renderer-status-store'
 export { useUpdateStore, setupUpdateListener } from './update-store'
 export { useImageStore, type ImageEntry, type MediaType } from './image-store'
 export { useContextWindowStore } from './context-window-store'

--- a/src/renderer/stores/settings-store.spec.ts
+++ b/src/renderer/stores/settings-store.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/constants'
 import type { AppSettings, ShellInfo } from '@shared/types'
 import { shouldImportLegacySettings, useSettingsStore } from './settings-store'
@@ -8,7 +8,24 @@ function cloneDefaultSettings(): AppSettings {
 }
 
 const settingsSet = vi.fn()
+const settingsGet = vi.fn()
 const zsh: ShellInfo = { path: '/bin/zsh', name: 'zsh', isDefault: true, kind: 'unix' }
+
+function installLocalStorage(initial?: string) {
+  let value = initial ?? null
+  const storage = {
+    getItem: vi.fn(() => value),
+    removeItem: vi.fn(() => { value = null }),
+    setItem: vi.fn((_key: string, next: string) => { value = next }),
+  }
+  vi.stubGlobal('localStorage', storage)
+  return storage
+}
+
+async function loadFreshSettingsStore() {
+  vi.resetModules()
+  return import('./settings-store')
+}
 
 describe('useSettingsStore', () => {
   beforeEach(() => {
@@ -16,11 +33,13 @@ describe('useSettingsStore', () => {
       ...cloneDefaultSettings(),
       ...partial,
     }))
+    settingsGet.mockReset().mockResolvedValue(cloneDefaultSettings())
     Object.defineProperty(globalThis, 'window', {
       value: {
         electron: {
           settings: {
-            set: settingsSet
+            set: settingsSet,
+            get: settingsGet,
           }
         }
       },
@@ -48,11 +67,35 @@ describe('useSettingsStore', () => {
     })
   })
 
-  it('keeps the settings alias in sync with pending terminalRenderMode updates', () => {
-    useSettingsStore.getState().setTerminalRenderMode('performance')
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
 
-    expect(useSettingsStore.getState().pendingSettings.terminalRenderMode).toBe('performance')
-    expect(useSettingsStore.getState().settings.terminalRenderMode).toBe('performance')
+  it('keeps the settings alias in sync with canonical renderer policy previews', () => {
+    useSettingsStore.getState().setTerminalRendererPolicy('safe-dom')
+
+    expect(useSettingsStore.getState().pendingSettings.terminalRendererPolicy).toBe('safe-dom')
+    expect(useSettingsStore.getState().settings.terminalRendererPolicy).toBe('safe-dom')
+    expect(useSettingsStore.getState().savedSettings.terminalRendererPolicy).toBe('automatic')
+    expect(useSettingsStore.getState().hasUnsavedChanges).toBe(true)
+  })
+
+  it('clears dirty state when a renderer policy preview returns to the saved value', () => {
+    useSettingsStore.getState().setTerminalRendererPolicy('prefer-gpu')
+    useSettingsStore.getState().setTerminalRendererPolicy('automatic')
+
+    expect(useSettingsStore.getState().hasUnsavedChanges).toBe(false)
+  })
+
+  it('synchronously restores pending settings and the compatibility alias on cancel', () => {
+    const saved = cloneDefaultSettings()
+    useSettingsStore.getState().setTerminalRendererPolicy('safe-dom')
+
+    useSettingsStore.getState().cancelSettings()
+
+    expect(useSettingsStore.getState().pendingSettings).toEqual(saved)
+    expect(useSettingsStore.getState().settings).toEqual(saved)
   })
 
   it('keeps all settings snapshots in sync when persisting the default shell', async () => {
@@ -134,6 +177,26 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().hasUnsavedChanges).toBe(false)
   })
 
+  it('captures the submitted profile and lets the canonical response replace later previews', async () => {
+    const submitted = { ...cloneDefaultSettings(), terminalRendererPolicy: 'prefer-gpu' as const }
+    const canonical = { ...cloneDefaultSettings(), terminalRendererPolicy: 'safe-dom' as const }
+    let resolveSave!: (settings: AppSettings) => void
+    settingsSet.mockReturnValueOnce(new Promise<AppSettings>((resolve) => {
+      resolveSave = resolve
+    }))
+    useSettingsStore.getState().setTerminalRendererPolicy('prefer-gpu')
+
+    const saving = useSettingsStore.getState().saveSettings()
+    useSettingsStore.getState().setColorTheme('dracula')
+    resolveSave(canonical)
+    await saving
+
+    expect(settingsSet).toHaveBeenCalledWith(submitted)
+    expect(useSettingsStore.getState().savedSettings).toEqual(canonical)
+    expect(useSettingsStore.getState().pendingSettings).toEqual(canonical)
+    expect(useSettingsStore.getState().settings).toEqual(canonical)
+  })
+
   it('rolls every settings snapshot back when persistence fails', async () => {
     const saved = cloneDefaultSettings()
     settingsSet.mockRejectedValueOnce(new Error('disk full'))
@@ -147,6 +210,19 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().hasUnsavedChanges).toBe(false)
   })
 
+  it('never logs complete settings records or raw save errors', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    useSettingsStore.getState().setTerminalRendererPolicy('prefer-gpu')
+    settingsSet.mockRejectedValueOnce(new Error('/Users/private/settings.json'))
+
+    await expect(useSettingsStore.getState().saveSettings()).rejects.toThrow()
+
+    expect(log).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith('[settings] Failed to save settings.')
+    expect(error).not.toHaveBeenCalledWith(expect.anything(), expect.anything())
+  })
+
   it('restores the live app-font preview when changes are cancelled', () => {
     useSettingsStore.getState().setModernFontFamily('inter')
     expect(document.body.style.fontFamily).toContain('Inter')
@@ -156,8 +232,12 @@ describe('useSettingsStore', () => {
     expect(document.body.style.fontFamily).not.toContain('Inter')
   })
 
-  it('imports legacy renderer settings only over an untouched main profile', () => {
+  it('imports legacy renderer settings over channel-only default differences', () => {
     expect(shouldImportLegacySettings(cloneDefaultSettings())).toBe(true)
+    expect(shouldImportLegacySettings({
+      ...cloneDefaultSettings(),
+      enableContextWindowAdvanced: true,
+    })).toBe(true)
     expect(shouldImportLegacySettings({
       ...cloneDefaultSettings(),
       colorTheme: 'dracula',
@@ -166,5 +246,59 @@ describe('useSettingsStore', () => {
       ...cloneDefaultSettings(),
       defaultShell: zsh,
     })).toBe(false)
+  })
+
+  it('keeps all snapshots canonical on load success and defaulted on load failure', async () => {
+    const canonical = { ...cloneDefaultSettings(), terminalRendererPolicy: 'safe-dom' as const }
+    installLocalStorage()
+    settingsGet.mockResolvedValueOnce(canonical)
+
+    await useSettingsStore.getState().loadSettings()
+    expect(useSettingsStore.getState().savedSettings).toEqual(canonical)
+    expect(useSettingsStore.getState().pendingSettings).toEqual(canonical)
+    expect(useSettingsStore.getState().settings).toEqual(canonical)
+
+    settingsGet.mockRejectedValueOnce(new Error('/private/profile'))
+    await useSettingsStore.getState().loadSettings()
+    expect(useSettingsStore.getState().savedSettings).toEqual(DEFAULT_SETTINGS)
+    expect(useSettingsStore.getState().pendingSettings).toEqual(DEFAULT_SETTINGS)
+    expect(useSettingsStore.getState().settings).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('adopts a successful one-time legacy import and deletes its local source', async () => {
+    const storage = installLocalStorage(JSON.stringify({ terminalRenderMode: 'quality' }))
+    const canonical = { ...cloneDefaultSettings(), terminalRendererPolicy: 'prefer-gpu' as const }
+    settingsSet.mockResolvedValueOnce(canonical)
+    const { useSettingsStore: freshStore } = await loadFreshSettingsStore()
+
+    await freshStore.getState().loadSettings()
+
+    expect(freshStore.getState().savedSettings).toEqual(canonical)
+    expect(freshStore.getState().pendingSettings).toEqual(canonical)
+    expect(freshStore.getState().settings).toEqual(canonical)
+    expect(storage.removeItem).toHaveBeenCalledWith('multiclaude-settings')
+  })
+
+  it('retains legacy local storage when canonical import fails', async () => {
+    const storage = installLocalStorage(JSON.stringify({ terminalRenderMode: 'quality' }))
+    settingsSet.mockRejectedValueOnce(new Error('/private/profile'))
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { useSettingsStore: freshStore } = await loadFreshSettingsStore()
+
+    await freshStore.getState().loadSettings()
+
+    expect(storage.removeItem).not.toHaveBeenCalled()
+    expect(warning).toHaveBeenCalledWith('[settings] Legacy settings import failed.')
+  })
+
+  it('deletes superseded legacy local storage when a customized main profile wins', async () => {
+    const storage = installLocalStorage(JSON.stringify({ terminalRenderMode: 'quality' }))
+    settingsGet.mockResolvedValueOnce({ ...cloneDefaultSettings(), colorTheme: 'dracula' })
+    const { useSettingsStore: freshStore } = await loadFreshSettingsStore()
+
+    await freshStore.getState().loadSettings()
+
+    expect(settingsSet).not.toHaveBeenCalled()
+    expect(storage.removeItem).toHaveBeenCalledWith('multiclaude-settings')
   })
 })

--- a/src/renderer/stores/settings-store.ts
+++ b/src/renderer/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { AppSettings, ThemeMode, ColorTheme, TerminalLimit, TerminalRenderMode, TerminalEngine, WslInfo, TerminalFontId, AppFontId, ShellInfo } from '@shared/types'
+import type { AppSettings, ThemeMode, ColorTheme, TerminalLimit, TerminalRendererPolicy, TerminalEngine, WslInfo, TerminalFontId, AppFontId, ShellInfo } from '@shared/types'
 import { DEFAULT_SETTINGS, APP_FONTS } from '@shared/constants'
 import { useToastStore } from './toast-store'
 
@@ -50,9 +50,8 @@ interface SettingsState {
   setThemeMode: (mode: ThemeMode) => void
   setColorTheme: (theme: ColorTheme) => void
   setTerminalLimit: (limit: TerminalLimit) => void
-  setTerminalRenderMode: (mode: TerminalRenderMode) => void
+  setTerminalRendererPolicy: (policy: TerminalRendererPolicy) => void
   setTerminalEngine: (engine: TerminalEngine) => void
-  setGpuRendererForClaudeTerminals: (enabled: boolean) => void
   setScrollbackLines: (lines: number) => void
   setEnableContextWindow: (enabled: boolean) => void
   setEnableContextWindowAdvanced: (enabled: boolean) => void
@@ -80,8 +79,7 @@ function areSettingsEqual(a: AppSettings, b: AppSettings): boolean {
   // Compare primitive fields
   if (a.themeMode !== b.themeMode) return false
   if (a.colorTheme !== b.colorTheme) return false
-  if (a.terminalRenderMode !== b.terminalRenderMode) return false
-  if (a.gpuRendererForClaudeTerminals !== b.gpuRendererForClaudeTerminals) return false
+  if (a.terminalRendererPolicy !== b.terminalRendererPolicy) return false
   if (a.scrollbackLines !== b.scrollbackLines) return false
   if (a.modernFontFamily !== b.modernFontFamily) return false
   if (a.terminalFontFamily !== b.terminalFontFamily) return false
@@ -106,7 +104,13 @@ function areSettingsEqual(a: AppSettings, b: AppSettings): boolean {
  * untouched default profile. A current main-owned preference always wins.
  */
 export function shouldImportLegacySettings(mainSettings: AppSettings): boolean {
-  return areSettingsEqual(mainSettings, DEFAULT_SETTINGS)
+  return areSettingsEqual(
+    {
+      ...mainSettings,
+      enableContextWindowAdvanced: DEFAULT_SETTINGS.enableContextWindowAdvanced,
+    },
+    DEFAULT_SETTINGS,
+  )
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -147,24 +151,17 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     })
   },
 
-  setTerminalRenderMode: (mode) => {
-    const pending = { ...get().pendingSettings, terminalRenderMode: mode }
+  setTerminalRendererPolicy: (policy) => {
+    const pending = { ...get().pendingSettings, terminalRendererPolicy: policy }
     set({
       pendingSettings: pending,
+      settings: pending,
       hasUnsavedChanges: !areSettingsEqual(pending, get().savedSettings)
     })
   },
 
   setTerminalEngine: (engine) => {
     const pending = { ...get().pendingSettings, terminalEngine: engine }
-    set({
-      pendingSettings: pending,
-      hasUnsavedChanges: !areSettingsEqual(pending, get().savedSettings)
-    })
-  },
-
-  setGpuRendererForClaudeTerminals: (enabled) => {
-    const pending = { ...get().pendingSettings, gpuRendererForClaudeTerminals: enabled }
     set({
       pendingSettings: pending,
       hasUnsavedChanges: !areSettingsEqual(pending, get().savedSettings)
@@ -210,8 +207,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         settings: pending,
         hasUnsavedChanges: !areSettingsEqual(pending, updated)
       })
-    } catch (err) {
-      console.error('[settings] Failed to persist defaultShell:', err)
+    } catch {
+      console.error('[settings] Failed to persist default shell.')
       const pending = get().pendingSettings
       set({
         savedSettings: saved,
@@ -244,10 +241,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   saveSettings: async () => {
     const pending = get().pendingSettings
     const saved = get().savedSettings
-    console.log('[settings] Saving settings:', pending)
     try {
       const result = await window.electron.settings.set(pending)
-      console.log('[settings] Save result from main:', result)
       set({
         savedSettings: result,
         pendingSettings: result,
@@ -255,9 +250,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         hasUnsavedChanges: false
       })
       if (result.modernFontFamily) applyAppFont(result.modernFontFamily)
-      console.log('[settings] savedSettings updated to:', get().savedSettings)
     } catch (err) {
-      console.error('Failed to save settings:', err)
+      console.error('[settings] Failed to save settings.')
       set({
         savedSettings: saved,
         pendingSettings: saved,
@@ -274,6 +268,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const saved = get().savedSettings
     set({
       pendingSettings: { ...saved },
+      settings: { ...saved },
       hasUnsavedChanges: false
     })
     if (saved.modernFontFamily) applyAppFont(saved.modernFontFamily)
@@ -314,21 +309,22 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
               hasUnsavedChanges: false
             })
             localStorage.removeItem(STORAGE_KEY)
-          } catch (migrationErr) {
-            // Log migration errors for debugging but don't fail the app
-            console.warn('[settings] localStorage migration failed:', migrationErr)
+          } catch {
+            console.warn('[settings] Legacy settings import failed.')
           }
         }
       }
-    } catch (err) {
-      console.error('Failed to load settings from disk:', err)
+    } catch {
+      console.error('[settings] Failed to load settings from disk.')
       useToastStore.getState().addToast(
         'Failed to load settings. Using defaults.',
         'warning'
       )
       set({
         savedSettings: DEFAULT_SETTINGS,
-        pendingSettings: DEFAULT_SETTINGS
+        pendingSettings: DEFAULT_SETTINGS,
+        settings: DEFAULT_SETTINGS,
+        hasUnsavedChanges: false,
       })
     }
   },

--- a/src/renderer/stores/terminal-renderer-status-store.spec.ts
+++ b/src/renderer/stores/terminal-renderer-status-store.spec.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  claimTerminalRendererSession,
+  getTerminalRendererStatus,
+  registerTerminalRendererRetry,
+  releaseTerminalRendererSession,
+  resetTerminalRendererStatusStoreForTests,
+  retryTerminalRenderer,
+  setTerminalRendererStatus,
+  useTerminalRendererStatusStore,
+} from './terminal-renderer-status-store'
+
+describe('terminal renderer status store', () => {
+  beforeEach(() => resetTerminalRendererStatusStoreForTests())
+
+  it('publishes only enum status for the owning session', () => {
+    const token = Symbol('session')
+    claimTerminalRendererSession('term-1', token)
+
+    expect(setTerminalRendererStatus('term-1', token, {
+      effective: 'dom',
+      fallbackReason: 'webgl-load-failed',
+    })).toBe(true)
+    expect(getTerminalRendererStatus('term-1')).toEqual({
+      terminalId: 'term-1',
+      effective: 'dom',
+      fallbackReason: 'webgl-load-failed',
+    })
+    expect(Object.keys(getTerminalRendererStatus('term-1')!)).toEqual([
+      'terminalId',
+      'effective',
+      'fallbackReason',
+    ])
+  })
+
+  it('rejects arbitrary effective and fallback strings at runtime', () => {
+    const token = Symbol('session')
+    claimTerminalRendererSession('term-1', token)
+
+    expect(setTerminalRendererStatus('term-1', token, {
+      effective: 'canvas',
+      fallbackReason: '/private/GPU driver error',
+    } as never)).toBe(false)
+    expect(getTerminalRendererStatus('term-1')).toBeUndefined()
+  })
+
+  it('isolates retry callbacks by terminal and keeps them out of public state', () => {
+    const tokenA = Symbol('a')
+    const tokenB = Symbol('b')
+    const retryA = vi.fn(() => true)
+    const retryB = vi.fn(() => false)
+    claimTerminalRendererSession('term-a', tokenA)
+    claimTerminalRendererSession('term-b', tokenB)
+    registerTerminalRendererRetry('term-a', tokenA, retryA)
+    registerTerminalRendererRetry('term-b', tokenB, retryB)
+
+    expect(retryTerminalRenderer('term-a')).toBe(true)
+    expect(retryTerminalRenderer('term-b')).toBe(false)
+    expect(retryA).toHaveBeenCalledTimes(1)
+    expect(retryB).toHaveBeenCalledTimes(1)
+    expect(useTerminalRendererStatusStore.getState()).not.toHaveProperty('retryCallbacks')
+  })
+
+  it('prevents an old same-ID session from updating or deleting its replacement', () => {
+    const oldToken = Symbol('old')
+    const newToken = Symbol('new')
+    claimTerminalRendererSession('term-1', oldToken)
+    setTerminalRendererStatus('term-1', oldToken, {
+      effective: 'webgl',
+      fallbackReason: null,
+    })
+    claimTerminalRendererSession('term-1', newToken)
+    setTerminalRendererStatus('term-1', newToken, {
+      effective: 'dom',
+      fallbackReason: 'automatic-agent-safe',
+    })
+
+    expect(setTerminalRendererStatus('term-1', oldToken, {
+      effective: 'dom',
+      fallbackReason: 'webgl-context-lost',
+    })).toBe(false)
+    releaseTerminalRendererSession('term-1', oldToken)
+    expect(getTerminalRendererStatus('term-1')?.fallbackReason)
+      .toBe('automatic-agent-safe')
+  })
+
+  it('synchronously removes status and retry on owning-session release', () => {
+    const token = Symbol('session')
+    claimTerminalRendererSession('term-1', token)
+    setTerminalRendererStatus('term-1', token, {
+      effective: 'webgl',
+      fallbackReason: null,
+    })
+    registerTerminalRendererRetry('term-1', token, () => true)
+
+    releaseTerminalRendererSession('term-1', token)
+
+    expect(getTerminalRendererStatus('term-1')).toBeUndefined()
+    expect(retryTerminalRenderer('term-1')).toBe(false)
+  })
+
+  it('lets only the current session unregister its retry callback', () => {
+    const oldToken = Symbol('old')
+    const newToken = Symbol('new')
+    const retryNew = vi.fn(() => true)
+    claimTerminalRendererSession('term-1', oldToken)
+    const staleUnsubscribe = registerTerminalRendererRetry(
+      'term-1',
+      oldToken,
+      () => false,
+    )
+    claimTerminalRendererSession('term-1', newToken)
+    registerTerminalRendererRetry('term-1', newToken, retryNew)
+
+    staleUnsubscribe()
+
+    expect(retryTerminalRenderer('term-1')).toBe(true)
+    expect(retryNew).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/stores/terminal-renderer-status-store.spec.ts
+++ b/src/renderer/stores/terminal-renderer-status-store.spec.ts
@@ -17,6 +17,8 @@ describe('terminal renderer status store', () => {
     const token = Symbol('session')
     claimTerminalRendererSession('term-1', token)
 
+    expect(useTerminalRendererStatusStore.getState().sessionCount).toBe(1)
+
     expect(setTerminalRendererStatus('term-1', token, {
       effective: 'dom',
       fallbackReason: 'webgl-load-failed',
@@ -97,6 +99,7 @@ describe('terminal renderer status store', () => {
 
     expect(getTerminalRendererStatus('term-1')).toBeUndefined()
     expect(retryTerminalRenderer('term-1')).toBe(false)
+    expect(useTerminalRendererStatusStore.getState().sessionCount).toBe(0)
   })
 
   it('lets only the current session unregister its retry callback', () => {

--- a/src/renderer/stores/terminal-renderer-status-store.ts
+++ b/src/renderer/stores/terminal-renderer-status-store.ts
@@ -1,0 +1,107 @@
+import { create } from 'zustand'
+import type {
+  DesiredTerminalRenderer,
+  RendererFallbackReason,
+} from '../utils/terminal-renderer-policy'
+
+export interface TerminalRendererStatus {
+  terminalId: string
+  effective: DesiredTerminalRenderer
+  fallbackReason: RendererFallbackReason | null
+}
+
+interface TerminalRendererStatusState {
+  statuses: Record<string, TerminalRendererStatus>
+}
+
+interface RetryControl {
+  token: symbol
+  retry: () => boolean
+}
+
+const EFFECTIVE_RENDERERS: ReadonlySet<DesiredTerminalRenderer> = new Set(['dom', 'webgl'])
+const FALLBACK_REASONS: ReadonlySet<RendererFallbackReason> = new Set([
+  'automatic-agent-safe',
+  'policy-safe',
+  'webgl-unavailable',
+  'webgl-load-failed',
+  'webgl-context-lost',
+])
+const sessionOwners = new Map<string, symbol>()
+const retryControls = new Map<string, RetryControl>()
+
+export const useTerminalRendererStatusStore = create<TerminalRendererStatusState>(() => ({
+  statuses: {},
+}))
+
+function removeStatus(terminalId: string): void {
+  useTerminalRendererStatusStore.setState((state) => {
+    if (!(terminalId in state.statuses)) return state
+    const statuses = { ...state.statuses }
+    delete statuses[terminalId]
+    return { statuses }
+  })
+}
+
+export function claimTerminalRendererSession(terminalId: string, token: symbol): void {
+  sessionOwners.set(terminalId, token)
+  retryControls.delete(terminalId)
+  removeStatus(terminalId)
+}
+
+export function setTerminalRendererStatus(
+  terminalId: string,
+  token: symbol,
+  status: Omit<TerminalRendererStatus, 'terminalId'>,
+): boolean {
+  if (sessionOwners.get(terminalId) !== token) return false
+  if (!EFFECTIVE_RENDERERS.has(status.effective)) return false
+  if (status.fallbackReason !== null && !FALLBACK_REASONS.has(status.fallbackReason)) {
+    return false
+  }
+  useTerminalRendererStatusStore.setState((state) => ({
+    statuses: {
+      ...state.statuses,
+      [terminalId]: { terminalId, ...status },
+    },
+  }))
+  return true
+}
+
+export function getTerminalRendererStatus(
+  terminalId: string,
+): TerminalRendererStatus | undefined {
+  return useTerminalRendererStatusStore.getState().statuses[terminalId]
+}
+
+export function registerTerminalRendererRetry(
+  terminalId: string,
+  token: symbol,
+  retry: () => boolean,
+): () => void {
+  if (sessionOwners.get(terminalId) !== token) return () => undefined
+  const control = { token, retry }
+  retryControls.set(terminalId, control)
+  return () => {
+    if (retryControls.get(terminalId) === control) retryControls.delete(terminalId)
+  }
+}
+
+export function retryTerminalRenderer(terminalId: string): boolean {
+  const control = retryControls.get(terminalId)
+  if (!control || sessionOwners.get(terminalId) !== control.token) return false
+  return control.retry()
+}
+
+export function releaseTerminalRendererSession(terminalId: string, token: symbol): void {
+  if (sessionOwners.get(terminalId) !== token) return
+  sessionOwners.delete(terminalId)
+  retryControls.delete(terminalId)
+  removeStatus(terminalId)
+}
+
+export function resetTerminalRendererStatusStoreForTests(): void {
+  sessionOwners.clear()
+  retryControls.clear()
+  useTerminalRendererStatusStore.setState({ statuses: {} })
+}

--- a/src/renderer/stores/terminal-renderer-status-store.ts
+++ b/src/renderer/stores/terminal-renderer-status-store.ts
@@ -12,6 +12,7 @@ export interface TerminalRendererStatus {
 
 interface TerminalRendererStatusState {
   statuses: Record<string, TerminalRendererStatus>
+  sessionCount: number
 }
 
 interface RetryControl {
@@ -32,6 +33,7 @@ const retryControls = new Map<string, RetryControl>()
 
 export const useTerminalRendererStatusStore = create<TerminalRendererStatusState>(() => ({
   statuses: {},
+  sessionCount: 0,
 }))
 
 function removeStatus(terminalId: string): void {
@@ -47,6 +49,7 @@ export function claimTerminalRendererSession(terminalId: string, token: symbol):
   sessionOwners.set(terminalId, token)
   retryControls.delete(terminalId)
   removeStatus(terminalId)
+  useTerminalRendererStatusStore.setState({ sessionCount: sessionOwners.size })
 }
 
 export function setTerminalRendererStatus(
@@ -98,10 +101,11 @@ export function releaseTerminalRendererSession(terminalId: string, token: symbol
   sessionOwners.delete(terminalId)
   retryControls.delete(terminalId)
   removeStatus(terminalId)
+  useTerminalRendererStatusStore.setState({ sessionCount: sessionOwners.size })
 }
 
 export function resetTerminalRendererStatusStoreForTests(): void {
   sessionOwners.clear()
   retryControls.clear()
-  useTerminalRendererStatusStore.setState({ statuses: {} })
+  useTerminalRendererStatusStore.setState({ statuses: {}, sessionCount: 0 })
 }

--- a/src/renderer/utils/terminal-lifecycle-dispatcher.ts
+++ b/src/renderer/utils/terminal-lifecycle-dispatcher.ts
@@ -12,8 +12,12 @@
 
 type SystemResumedCallback = () => void
 
-// Per-terminal subscriber map: terminalId → callback
-const systemResumeHandlers = new Map<string, SystemResumedCallback>()
+interface SystemResumeSubscription {
+  token: symbol
+  callback: SystemResumedCallback
+}
+
+const systemResumeHandlers = new Map<string, SystemResumeSubscription>()
 
 /**
  * Subscribe a terminal to system-resume events.
@@ -21,16 +25,28 @@ const systemResumeHandlers = new Map<string, SystemResumedCallback>()
  */
 export function subscribeToSystemResume(
   terminalId: string,
-  callback: SystemResumedCallback
-): void {
-  systemResumeHandlers.set(terminalId, callback)
+  tokenOrCallback: symbol | SystemResumedCallback,
+  maybeCallback?: SystemResumedCallback,
+): () => void {
+  const token = typeof tokenOrCallback === 'symbol' ? tokenOrCallback : Symbol('legacy-session')
+  const callback = typeof tokenOrCallback === 'function' ? tokenOrCallback : maybeCallback
+  if (!callback) return () => undefined
+  const subscription = { token, callback }
+  systemResumeHandlers.set(terminalId, subscription)
+  return () => {
+    if (systemResumeHandlers.get(terminalId) === subscription) {
+      systemResumeHandlers.delete(terminalId)
+    }
+  }
 }
 
 /**
  * Unsubscribe a terminal from system-resume events.
  * Safe to call if terminalId was never subscribed.
  */
-export function unsubscribeFromSystemResume(terminalId: string): void {
+export function unsubscribeFromSystemResume(terminalId: string, token?: symbol): void {
+  const subscription = systemResumeHandlers.get(terminalId)
+  if (!subscription || (token !== undefined && subscription.token !== token)) return
   systemResumeHandlers.delete(terminalId)
 }
 
@@ -53,12 +69,12 @@ export function attachTerminalLifecycleDispatcher(
 ): () => void {
   return subscribe(() => {
     // Fan out to all currently subscribed terminals
-    for (const [, handler] of systemResumeHandlers) {
+    for (const [, { callback }] of systemResumeHandlers) {
       try {
-        handler()
-      } catch (err) {
+        callback()
+      } catch {
         // Guard: one failing handler must not block others
-        console.error('[lifecycle-dispatcher] system-resume handler threw:', err)
+        console.error('[lifecycle-dispatcher] System-resume handler failed.')
       }
     }
   })

--- a/src/renderer/utils/terminal-output-dispatcher.spec.ts
+++ b/src/renderer/utils/terminal-output-dispatcher.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   attachTerminalOutputDispatcher,
+  claimTerminalOutputSession,
   pauseAndBuffer,
   registerTerminalOutputHandler,
   resetTerminalOutputDispatcherForTests,
@@ -127,6 +128,50 @@ describe('terminal-output-dispatcher', () => {
     expect(newerHandler).toHaveBeenCalledWith('hello')
 
     unsubscribe()
+  })
+
+  it('rejects stale same-ID resume work from an old renderer session', () => {
+    const oldToken = Symbol('old')
+    const newToken = Symbol('new')
+    const oldHandler = vi.fn()
+    const newHandler = vi.fn()
+    claimTerminalOutputSession('term-1', oldToken)
+    registerTerminalOutputHandler('term-1', oldHandler, undefined, oldToken)
+    pauseAndBuffer('term-1', oldToken)
+    attachTerminalOutputDispatcher(callback => {
+      callback(chunk('term-1', 1, 'owned-by-current-session'))
+      return vi.fn()
+    })
+
+    claimTerminalOutputSession('term-1', newToken)
+    registerTerminalOutputHandler('term-1', newHandler, undefined, newToken)
+    pauseAndBuffer('term-1', newToken)
+    resumeAndFlush('term-1', oldToken)
+    expect(oldHandler).not.toHaveBeenCalled()
+    expect(newHandler).not.toHaveBeenCalled()
+
+    resumeAndFlush('term-1', newToken)
+    expect(newHandler).toHaveBeenCalledWith('owned-by-current-session')
+  })
+
+  it('rejects a stale snapshot watermark from an old renderer session', () => {
+    const oldToken = Symbol('old')
+    const newToken = Symbol('new')
+    const newHandler = vi.fn()
+    claimTerminalOutputSession('term-1', oldToken)
+    claimTerminalOutputSession('term-1', newToken)
+    registerTerminalOutputHandler('term-1', newHandler, undefined, newToken)
+    pauseAndBuffer('term-1', newToken)
+    attachTerminalOutputDispatcher(callback => {
+      callback(chunk('term-1', 1, 'new-session-output'))
+      return vi.fn()
+    })
+
+    resumeFromSnapshot(emptySnapshot('term-1', 99), oldToken)
+    expect(newHandler).not.toHaveBeenCalled()
+
+    resumeFromSnapshot(emptySnapshot('term-1'), newToken)
+    expect(newHandler).toHaveBeenCalledWith('new-session-output')
   })
 
   it('attach helper returns the unsubscribe from the underlying subscribe function', () => {

--- a/src/renderer/utils/terminal-output-dispatcher.ts
+++ b/src/renderer/utils/terminal-output-dispatcher.ts
@@ -23,6 +23,22 @@ interface StreamState {
   recoveryTimer?: ReturnType<typeof setTimeout>
   recoveryInFlight: boolean
   explicitlyPaused: boolean
+  ownerToken?: symbol
+}
+
+function isOwnedBy(state: StreamState, token?: symbol): boolean {
+  return token === undefined || state.ownerToken === token
+}
+
+export function claimTerminalOutputSession(id: string, token: symbol): void {
+  const state = getState(id)
+  if (state.ownerToken === token) return
+  state.ownerToken = token
+  state.handler = undefined
+  state.recoveryHandler = undefined
+  state.status = 'hydrating'
+  state.explicitlyPaused = true
+  clearRecovery(state)
 }
 
 const states = new Map<string, StreamState>()
@@ -131,8 +147,9 @@ function flushPending(id: string, state: StreamState): void {
 }
 
 /** Pause delivery while a full terminal snapshot is being applied. */
-export function pauseAndBuffer(id: string): void {
+export function pauseAndBuffer(id: string, token?: symbol): void {
   const state = getState(id)
+  if (!isOwnedBy(state, token)) return
   if (state.status !== 'disposed') {
     state.status = 'hydrating'
     state.explicitlyPaused = true
@@ -143,9 +160,9 @@ export function pauseAndBuffer(id: string): void {
  * Complete hydration at an atomic snapshot watermark and apply only later
  * envelopes from the same terminal lifetime.
  */
-export function resumeFromSnapshot(snapshot: TerminalSnapshot): void {
+export function resumeFromSnapshot(snapshot: TerminalSnapshot, token?: symbol): void {
   const state = states.get(snapshot.terminalId)
-  if (!state) return
+  if (!state || !isOwnedBy(state, token)) return
   clearRecovery(state)
   state.streamEpoch = snapshot.streamEpoch
   state.lastAppliedSequence = snapshot.watermark
@@ -158,9 +175,9 @@ export function resumeFromSnapshot(snapshot: TerminalSnapshot): void {
  * Resume sequenced live delivery when snapshot hydration is unavailable.
  * Normal snapshot paths must call resumeFromSnapshot().
  */
-export function resumeAndFlush(id: string): void {
+export function resumeAndFlush(id: string, token?: symbol): void {
   const state = states.get(id)
-  if (!state) return
+  if (!state || !isOwnedBy(state, token)) return
   if (!state.streamEpoch) {
     const first = state.pending[0]
     state.streamEpoch = first?.streamEpoch ?? null
@@ -175,9 +192,11 @@ export function resumeAndFlush(id: string): void {
 export function registerTerminalOutputHandler(
   id: string,
   handler: TerminalOutputHandler,
-  recoveryHandler?: RecoveryHandler
+  recoveryHandler?: RecoveryHandler,
+  token?: symbol,
 ): () => void {
   const state = getState(id)
+  if (!isOwnedBy(state, token)) return () => undefined
   state.handler = handler
   state.recoveryHandler = recoveryHandler
   if (state.status === 'live') flushPending(id, state)
@@ -186,7 +205,7 @@ export function registerTerminalOutputHandler(
 
   return () => {
     const current = states.get(id)
-    if (!current || current.handler !== handler) return
+    if (!current || !isOwnedBy(current, token) || current.handler !== handler) return
     current.handler = undefined
     current.recoveryHandler = undefined
     if (current.status === 'live') current.status = 'gap'

--- a/src/renderer/utils/terminal-renderer-policy.spec.ts
+++ b/src/renderer/utils/terminal-renderer-policy.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentType } from '@shared/types'
+import {
+  isSafeAgentTerminal,
+  resolveTerminalRenderer,
+} from './terminal-renderer-policy'
+
+describe('terminal renderer policy', () => {
+  it.each([
+    [undefined, false, false],
+    ['generic', false, false],
+    ['gemini', false, false],
+    ['aider', false, false],
+    ['claude', false, true],
+    ['codex', false, true],
+    ['generic', true, true],
+  ] as const)(
+    'classifies agent=%s legacyClaude=%s as safe=%s',
+    (agentType, isClaudeMode, expected) => {
+      expect(isSafeAgentTerminal({ agentType, isClaudeMode })).toBe(expected)
+    },
+  )
+
+  it.each([
+    ['automatic', 'generic', false, 'webgl', null],
+    ['automatic', 'gemini', false, 'webgl', null],
+    ['automatic', 'aider', false, 'webgl', null],
+    ['automatic', undefined, false, 'webgl', null],
+    ['automatic', 'claude', false, 'dom', 'automatic-agent-safe'],
+    ['automatic', 'codex', false, 'dom', 'automatic-agent-safe'],
+    ['automatic', 'generic', true, 'dom', 'automatic-agent-safe'],
+    ['prefer-gpu', 'claude', false, 'webgl', null],
+    ['prefer-gpu', 'codex', false, 'webgl', null],
+    ['prefer-gpu', 'generic', true, 'webgl', null],
+    ['safe-dom', 'generic', false, 'dom', 'policy-safe'],
+    ['safe-dom', 'claude', false, 'dom', 'policy-safe'],
+    ['safe-dom', 'codex', false, 'dom', 'policy-safe'],
+  ] as const)(
+    'resolves %s agent=%s legacyClaude=%s to %s/%s',
+    (policy, agentType, isClaudeMode, desired, fallbackReason) => {
+      expect(resolveTerminalRenderer({ policy, agentType, isClaudeMode })).toEqual({
+        desired,
+        fallbackReason,
+      })
+    },
+  )
+
+  it('covers every declared agent type under every policy', () => {
+    const agentTypes: AgentType[] = ['claude', 'codex', 'gemini', 'aider', 'generic']
+    const policies = ['automatic', 'prefer-gpu', 'safe-dom'] as const
+
+    for (const policy of policies) {
+      for (const agentType of agentTypes) {
+        expect(resolveTerminalRenderer({ policy, agentType, isClaudeMode: false }).desired)
+          .toMatch(/^(dom|webgl)$/)
+      }
+    }
+  })
+})

--- a/src/renderer/utils/terminal-renderer-policy.ts
+++ b/src/renderer/utils/terminal-renderer-policy.ts
@@ -1,0 +1,44 @@
+import type { AgentType, TerminalRendererPolicy } from '@shared/types'
+
+export type DesiredTerminalRenderer = 'dom' | 'webgl'
+export type RendererFallbackReason =
+  | 'automatic-agent-safe'
+  | 'policy-safe'
+  | 'webgl-unavailable'
+  | 'webgl-load-failed'
+  | 'webgl-context-lost'
+
+interface TerminalClassification {
+  agentType?: AgentType
+  isClaudeMode?: boolean
+}
+
+interface ResolveTerminalRendererInput extends TerminalClassification {
+  policy: TerminalRendererPolicy
+}
+
+export interface ResolvedTerminalRenderer {
+  desired: DesiredTerminalRenderer
+  fallbackReason: RendererFallbackReason | null
+}
+
+export function isSafeAgentTerminal({
+  agentType,
+  isClaudeMode = false,
+}: TerminalClassification): boolean {
+  return isClaudeMode || agentType === 'claude' || agentType === 'codex'
+}
+
+export function resolveTerminalRenderer({
+  policy,
+  agentType,
+  isClaudeMode,
+}: ResolveTerminalRendererInput): ResolvedTerminalRenderer {
+  if (policy === 'safe-dom') {
+    return { desired: 'dom', fallbackReason: 'policy-safe' }
+  }
+  if (policy === 'automatic' && isSafeAgentTerminal({ agentType, isClaudeMode })) {
+    return { desired: 'dom', fallbackReason: 'automatic-agent-safe' }
+  }
+  return { desired: 'webgl', fallbackReason: null }
+}

--- a/src/shared/constants/themes.ts
+++ b/src/shared/constants/themes.ts
@@ -320,12 +320,11 @@ export const COLOR_THEMES: ColorThemeDefinition[] = [
 export const DEFAULT_ACTIVITY_BAR_STATE = 'collapsed' as const
 
 export const DEFAULT_SETTINGS: AppSettings = {
-  settingsSchemaVersion: 1,
+  settingsSchemaVersion: 2,
   terminalEngine: 'xterm',
   colorTheme: 'tokyo-night',
   terminalLimit: { preset: 9 },
-  terminalRenderMode: 'balanced',
-  gpuRendererForClaudeTerminals: false,
+  terminalRendererPolicy: 'automatic',
   scrollbackLines: SCROLLBACK_DEFAULT,
   terminalFontFamily: 'jetbrains-mono',
   // Legacy fields - kept for backward compat with saved user settings + use-terminal hook

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -194,8 +194,7 @@ export type ColorTheme =
   // New VibeTerminal themes
   | 'tokyo-night' | 'catppuccin' | 'dracula' | 'rose-pine' | 'pro-dark'
 
-// Terminal rendering mode: performance (no WebGL), balanced (WebGL for active only), quality (always WebGL)
-export type TerminalRenderMode = 'performance' | 'balanced' | 'quality'
+export type TerminalRendererPolicy = 'automatic' | 'prefer-gpu' | 'safe-dom'
 export type TerminalEngine = 'xterm' | 'ghostty'
 
 // UI Style types for Terminal/TUI mode
@@ -267,8 +266,7 @@ export interface AppSettings {
   terminalEngine: TerminalEngine
   colorTheme: ColorTheme
   terminalLimit: TerminalLimit
-  terminalRenderMode: TerminalRenderMode
-  gpuRendererForClaudeTerminals?: boolean
+  terminalRendererPolicy: TerminalRendererPolicy
   /**
    * Number of lines xterm.js keeps in the scrollback buffer.
    * Higher values let the user scroll further back but use more memory


### PR DESCRIPTION
## End-to-end work summary

Implemented the accepted automatic terminal renderer policy plan from schema migration through renderer lifecycle, Diagnostics UI, packaged validation, documentation, independent testing, and two-stage review. The branch replaces the legacy rendering modes with Automatic, Prefer GPU, and Compatibility, then ships the completed change to the `beta` integration branch for review.

Closes #21

## Subagent delegation

Four delegated roles contributed:

- Advisor: audited implementation and packaged evidence, initially blocked on a complete retries-disabled UI run, then returned GO after 164/164 passed.
- Frontend/E2E implementer: completed the Settings modal and Electron policy/status/exact-once coverage; focused suites passed.
- Tester: independently verified typecheck, 23/23 benchmark tests, 70/70 focused Vitest tests, 4/4 renderer Electron tests, contract searches, and all nine packaged canary rows.
- Code reviewer: ran three evidence-based cycles; profile-path safety, stale docs, missing validation cases, and accessibility associations were corrected; final Stage 1 and Stage 2 verdicts are PASS with no remaining findings.

## Technical decisions

- Main-owned schema v2 stores only `automatic | prefer-gpu | safe-dom`; retired renderer keys are migrated presence-aware and never dual-written.
- One renderer-session controller owns lazy WebGL allocation, context-loss suppression, DOM fallback, Retry GPU, disposal, and enum-only status publication.
- Automatic keeps Claude/Codex on DOM while generic terminals attempt WebGL; Compatibility never attempts WebGL.
- Settings changes preview locally and Save/Cancel govern the whole modal, including rollback on every dismissal path and locking while Save is pending.
- Packaged evidence remains content-free, uses redacted executable identifiers, rejects broad/symlinked profile roots, and fails closed on provenance or memory-analysis mismatch.

## Deviations from plan

- The first 9-pane 1,800-second Automatic report was honestly rejected because heap OLS slope was 1.68 MiB/min against a 1.35 limit. It is retained unchanged; an independent rerun under identical thresholds passed.
- Two pre-existing Electron synchronization defects exposed by retries-disabled validation were corrected in terminal-title Escape handling and serialized scrollback paging.
- Review added explicit packaged terminal-close/status cleanup, Electron unknown-fallback sanitization, exact-once markers across policy transitions, stronger profile-path guards, and programmatic radio descriptions. These close stated acceptance gaps without expanding product scope.

## Completion evidence

- `npm run typecheck`: passed.
- `npm run lint`: passed with zero errors and three known pre-existing warnings.
- `npm test`: 137 files, 1,332 passed, 8 skipped, 5 todo.
- Full desktop Electron suite with retries disabled: 164/164 expected, zero unexpected/flaky/skipped.
- Focused renderer Electron suite after review fixes: 4/4; earlier six-file renderer matrix: 50/50.
- Benchmark helpers: 23/23.
- Automatic, Prefer GPU, and Compatibility short packaged canaries: all 1/4/9 rows passed terminal correctness, renderer status, and cleanup evidence.
- Mandatory Automatic 1/4/9 memory evidence passed the fail-closed analyzer using the accepted 9-pane rerun; the original rejected 9-pane evidence remains retained.
- Build, package smoke, release-helper tests, downgrade/recovery sequence, privacy scans, stale-contract searches, one-constructor check, and diff checks passed.
- Pre-landing code review: Stage 1 PASS; Stage 2 PASS; no remaining Critical, Important, or Minor findings.
- UI screenshot unavailable in this CLI-only ship path; semantic UI, keyboard, accessibility, persistence, status, and fallback behavior are covered by component and desktop Electron tests.

## Checklist

- [x] Canonical settings migration and main validation
- [x] Renderer lifecycle, fallback, retry, cleanup, and same-ID session ownership
- [x] Accessible Diagnostics policy controls and content-free runtime status
- [x] Exact-once output across policy and project transitions
- [x] 1/4/9 packaged policy canaries and 1,800-second Automatic memory gates
- [x] Previous-beta preserved-profile downgrade/recovery validation
- [x] Current README/spec/architecture documentation synchronized
- [x] Type, lint, unit, Electron, build, package, helper, privacy, and review gates
- [ ] Release publication/version bump — intentionally not performed; it requires separate version authorization

Ship Mode: beta PR targeting `beta`.

## Human actions required

Review and merge this PR when ready. Publishing a beta version, creating a tag, or dispatching the release workflow remains a separate explicit action.

PR prose uses the documented English fallback because the writing-language resolver hook is unavailable and no repository or user language preference is configured.
