### PR TITLE
fix(release): unblock cross-platform verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify types, lint, and unit tests
-        run: |
-          npm run typecheck
-          npm run lint
-          npm test
-          npm run test:benchmarks
-          npm run test:release
+      # Keep each native command in its own step. PowerShell does not fail a
+      # multiline step when an earlier native command exits non-zero, which can
+      # otherwise hide a failed test suite on Windows.
+      - name: Verify types
+        run: npm run typecheck
+
+      - name: Verify lint
+        run: npm run lint
+
+      - name: Verify unit tests
+        run: npm test
+
+      - name: Verify benchmarks
+        run: npm run test:benchmarks
+
+      - name: Verify release scripts
+        run: npm run test:release
 
       - name: Build with manifests (all platforms)
         run: npm run build:ci

--- a/scripts/benchmarks/packaged-terminal-soak-lib.mjs
+++ b/scripts/benchmarks/packaged-terminal-soak-lib.mjs
@@ -39,7 +39,10 @@ function validateExplicitProfileDirectory(candidate) {
   const physicalHome = resolveThroughExistingAncestor(path.resolve(os.homedir()))
   const physicalWorkspace = resolveThroughExistingAncestor(path.resolve(process.cwd()))
   const temporaryRoots = [os.tmpdir()]
-  if (process.platform !== 'win32') temporaryRoots.push('/tmp', '/var/tmp')
+  // Keep the common macOS spelling even on Linux. `/private/tmp` is normally a
+  // symlink to `/tmp` on macOS, but can be a distinct (or absent) broad path on
+  // Linux; both spellings must be rejected before a profile is created there.
+  if (process.platform !== 'win32') temporaryRoots.push('/tmp', '/private/tmp', '/var/tmp')
   const physicalTemporaryRoots = temporaryRoots.map(root =>
     resolveThroughExistingAncestor(path.resolve(root))
   )

--- a/scripts/release/release-workflow.spec.mjs
+++ b/scripts/release/release-workflow.spec.mjs
@@ -33,3 +33,17 @@ test('keeps macOS releases compatible with the previous ad-hoc signing contract'
     assert.doesNotMatch(workflow, new RegExp(productionOnlySetting.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
   }
 })
+
+test('runs every verification command in a fail-fast workflow step', () => {
+  for (const [name, command] of [
+    ['Verify types', 'npm run typecheck'],
+    ['Verify lint', 'npm run lint'],
+    ['Verify unit tests', 'npm test'],
+    ['Verify benchmarks', 'npm run test:benchmarks'],
+    ['Verify release scripts', 'npm run test:release'],
+  ]) {
+    assert.match(workflow, new RegExp(`- name: ${name}\\n\\s+run: ${command.replace(/\//g, '\\/')}`))
+  }
+
+  assert.doesNotMatch(workflow, /run: \|\n(?:\s+npm (?:run )?[^\n]+\n){2,}/)
+})

--- a/src/__tests__/e2e/tests/terminal-stream-correctness.spec.ts
+++ b/src/__tests__/e2e/tests/terminal-stream-correctness.spec.ts
@@ -68,8 +68,17 @@ test.describe('Terminal Stream Correctness', () => {
     // contain a marker more than once without duplicating an output envelope.
     expect(result.deliveredMarkerCount).toBeGreaterThanOrEqual(1)
     expect(result.deliveredAfterResizeMarkerCount).toBeGreaterThanOrEqual(1)
-    expect(result.canonicalMarkerCount).toBe(1)
-    expect(result.canonicalAfterResizeMarkerCount).toBe(1)
+    // The canonical mirror consumes the PTY byte stream faithfully. ConPTY may
+    // repaint visible text after a resize, so textual occurrence counts are not
+    // an exact-once signal. The mirror must retain each marker without inventing
+    // more occurrences than the PTY delivered; envelope sequences below enforce
+    // the actual exact-once transport contract.
+    expect(result.canonicalMarkerCount).toBeGreaterThanOrEqual(1)
+    expect(result.canonicalMarkerCount).toBeLessThanOrEqual(result.deliveredMarkerCount)
+    expect(result.canonicalAfterResizeMarkerCount).toBeGreaterThanOrEqual(1)
+    expect(result.canonicalAfterResizeMarkerCount).toBeLessThanOrEqual(
+      result.deliveredAfterResizeMarkerCount,
+    )
     expect(result.epochs).toHaveLength(1)
     expect(result.sequences).toEqual(
       Array.from({ length: result.sequences.at(-1) ?? 0 }, (_, index) => index + 1),

--- a/src/main/terminal/__tests__/terminal-manager.spec.ts
+++ b/src/main/terminal/__tests__/terminal-manager.spec.ts
@@ -289,7 +289,7 @@ describe('TerminalManager', () => {
       process.env.ProgramFiles = 'C:\\Program Files'
       mockSpawnSync.mockReturnValue({ status: 1 })
       mockExistsSync.mockImplementation((target: string) => (
-        target === 'C:\\Program Files/PowerShell' || target === 'C:\\Program Files/PowerShell/7/pwsh.exe'
+        target === 'C:\\Program Files\\PowerShell' || target === 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
       ))
       mockReaddirSync.mockReturnValue([
         {
@@ -302,7 +302,7 @@ describe('TerminalManager', () => {
       winManager.create({ shell: { type: 'powershell' } })
 
       expect(pty.spawn).toHaveBeenCalledWith(
-        'C:\\Program Files/PowerShell/7/pwsh.exe',
+        'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
         ['-NoLogo'],
         expect.objectContaining({ name: 'xterm-256color' })
       )

--- a/src/main/terminal/terminal-manager.ts
+++ b/src/main/terminal/terminal-manager.ts
@@ -226,7 +226,7 @@ export class TerminalManager extends EventEmitter {
 
     const powerShellRoots = [process.env.ProgramFiles, process.env['ProgramFiles(x86)']]
       .filter((root): root is string => typeof root === 'string' && root.length > 0)
-      .map(root => path.join(root, 'PowerShell'))
+      .map(root => path.win32.join(root, 'PowerShell'))
 
     for (const root of powerShellRoots) {
       if (!existsSync(root)) continue
@@ -234,7 +234,7 @@ export class TerminalManager extends EventEmitter {
       try {
         const candidates = readdirSync(root, { withFileTypes: true })
           .filter(entry => entry.isDirectory())
-          .map(entry => path.join(root, entry.name, 'pwsh.exe'))
+          .map(entry => path.win32.join(root, entry.name, 'pwsh.exe'))
           .filter(candidate => existsSync(candidate))
           .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
 


### PR DESCRIPTION
## Summary
- reject `/private/tmp` as a broad explicit soak profile on every non-Windows host, including Linux where it is not a `/tmp` symlink
- use Windows path semantics for PowerShell discovery and validate terminal exact-once delivery by stream envelopes while allowing ConPTY resize repaint bytes in canonical snapshots
- split release verification commands into independent workflow steps so PowerShell cannot mask an earlier native command failure

## Root causes
- Linux preserved `/private/tmp` as a distinct path, but the profile guard only listed `/tmp` and `/var/tmp`
- ConPTY legitimately repaints visible terminal text after resize; textual marker count was therefore stricter than the exact-once transport contract already enforced by epoch and contiguous sequence assertions
- Windows PowerShell multiline workflow steps can continue after a native command exits non-zero, allowing later commands to hide the original failure

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 1333 passed
- [x] `npm run test:benchmarks` — 24 passed
- [x] `npm run test:release` — 23 passed
- [x] `npm run test:ui -- --grep "Terminal Stream Correctness"` — 1 passed, retries=0
- [x] `npm run build:ci`
- [x] Independent review — PASS