### PR TITLE
test(release): support Windows workflow newlines

### DIFF
--- a/scripts/release/release-workflow.spec.mjs
+++ b/scripts/release/release-workflow.spec.mjs
@@ -35,15 +35,24 @@ test('keeps macOS releases compatible with the previous ad-hoc signing contract'
 })
 
 test('runs every verification command in a fail-fast workflow step', () => {
-  for (const [name, command] of [
-    ['Verify types', 'npm run typecheck'],
-    ['Verify lint', 'npm run lint'],
-    ['Verify unit tests', 'npm test'],
-    ['Verify benchmarks', 'npm run test:benchmarks'],
-    ['Verify release scripts', 'npm run test:release'],
-  ]) {
-    assert.match(workflow, new RegExp(`- name: ${name}\\n\\s+run: ${command.replace(/\//g, '\\/')}`))
-  }
+  for (const newline of ['\n', '\r\n']) {
+    const workflowWithPlatformNewlines = workflow.replace(/\r?\n/g, newline)
+    for (const [name, command] of [
+      ['Verify types', 'npm run typecheck'],
+      ['Verify lint', 'npm run lint'],
+      ['Verify unit tests', 'npm test'],
+      ['Verify benchmarks', 'npm run test:benchmarks'],
+      ['Verify release scripts', 'npm run test:release'],
+    ]) {
+      assert.match(
+        workflowWithPlatformNewlines,
+        new RegExp(`- name: ${name}\\r?\\n\\s+run: ${command.replace(/\//g, '\\/')}`),
+      )
+    }
 
-  assert.doesNotMatch(workflow, /run: \|\n(?:\s+npm (?:run )?[^\n]+\n){2,}/)
+    assert.doesNotMatch(
+      workflowWithPlatformNewlines,
+      /run: \|\r?\n(?:\s+npm (?:run )?[^\r\n]+\r?\n){2,}/,
+    )
+  }
 })


### PR DESCRIPTION
## Summary
- make the release workflow regression accept both LF and CRLF line endings
- exercise the fail-fast step assertions against both newline forms

## Root cause
Release run [31365255912](https://github.com/nguyennguyenit/MultiClaude/actions/runs/31365255912) checked out the workflow with Windows CRLF newlines, while the Node test regex required LF-only boundaries. The workflow behavior was correct; the platform-sensitive test failed.

## Verification
- [x] `npm run test:release` — 23/23 passed
- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors
- [x] `git diff --check`
- [x] Independent review — PASS